### PR TITLE
fix(deploy): use the domain's PHP version instead of the newest installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.0.3
+
+- Fix deploy running under the wrong PHP version: `_getPhpBinDir()` no longer silently falls back to the newest installed PHP (e.g. 8.5) when the domain's PHP handler can't be parsed
+- Add a per-domain **PHP Version** deploy setting (auto-detect by default; pin a version to override)
+- Harden PHP handler-id parsing and log the resolved/fallback PHP version for diagnosability
+
 ## v1.5.0
 
 - Fix webhook endpoint: move to `htdocs/public/` for unauthenticated access

--- a/xve-laravel-kit/src/meta.xml
+++ b/xve-laravel-kit/src/meta.xml
@@ -4,7 +4,7 @@
     <name>XVE Laravel Kit</name>
     <description>Atomic deployments with rollback, Laravel management tools, .env editor, artisan console, and log viewer. Built for zero-downtime deploys from Git repositories.</description>
     <category>developer</category>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <release>1</release>
     <vendor>XVE BV</vendor>
     <url>https://xve.be</url>

--- a/xve-laravel-kit/src/plib/controllers/DomainController.php
+++ b/xve-laravel-kit/src/plib/controllers/DomainController.php
@@ -195,6 +195,7 @@ class DomainController extends pm_Controller_Action
             $this->_settings->setSharedDirs($form->getValue('shared_dirs'));
             $this->_settings->setSharedFiles($form->getValue('shared_files'));
             $this->_settings->setDeployMode($form->getValue('deploy_mode'));
+            $this->_settings->setPhpVersion($form->getValue('php_version'));
             $this->_settings->setNodeVersion($form->getValue('node_version'));
             $this->_settings->setNodePackageManager($form->getValue('node_pm'));
             foreach (array_keys(Modules_XveLaravelKit_DeploySettings::STEPS) as $step) {

--- a/xve-laravel-kit/src/plib/library/DeploySettings.php
+++ b/xve-laravel-kit/src/plib/library/DeploySettings.php
@@ -262,6 +262,62 @@ class Modules_XveLaravelKit_DeploySettings
         return $versions;
     }
 
+    // -- PHP version --
+
+    /**
+     * Selected PHP version for deploys. 'auto' = detect from the domain's
+     * Plesk PHP handler (recommended). An explicit "8.4" pins that version.
+     */
+    public function getPhpVersion()
+    {
+        return pm_Settings::get($this->_prefix . 'php_version', 'auto');
+    }
+
+    public function setPhpVersion($value)
+    {
+        pm_Settings::set($this->_prefix . 'php_version', $value);
+    }
+
+    /**
+     * Bin directory for the explicitly selected PHP version, or '' when set to
+     * 'auto' (let the Deployer detect it from the domain's PHP handler).
+     */
+    public function getPhpBinDir()
+    {
+        $version = $this->getPhpVersion();
+        if ($version === 'auto' || $version === 'system' || empty($version)) {
+            return '';
+        }
+        return '/opt/plesk/php/' . $version . '/bin';
+    }
+
+    /**
+     * Discover installed Plesk PHP versions from /opt/plesk/php.
+     * Returns array like ['8.4' => '8.4', ...] (only versions with a php binary).
+     */
+    public static function getAvailablePhpVersions()
+    {
+        $versions = [];
+        $baseDir = '/opt/plesk/php';
+        if (!is_dir($baseDir)) {
+            return $versions;
+        }
+        $dirs = @scandir($baseDir);
+        if (!is_array($dirs)) {
+            return $versions;
+        }
+        foreach ($dirs as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            if (file_exists($baseDir . '/' . $entry . '/bin/php')) {
+                $versions[$entry] = $entry;
+            }
+        }
+        uksort($versions, 'version_compare');
+        return $versions;
+    }
+
     // -- Shared directories / files --
 
     const DEFAULT_SHARED_DIRS = "storage\nlogs";

--- a/xve-laravel-kit/src/plib/library/Deployer.php
+++ b/xve-laravel-kit/src/plib/library/Deployer.php
@@ -1462,21 +1462,44 @@ class Modules_XveLaravelKit_Deployer
 
     private function _getPhpBinDir()
     {
+        // 1. Explicit per-domain override (Settings -> "PHP Version"). Authoritative.
         try {
-            $phpHandler = $this->_domain->getPhpHandlerId();
-            if (preg_match('/plesk-php(\d)(\d)/', $phpHandler, $m)) {
-                $version = $m[1] . '.' . $m[2];
-                $dir = '/opt/plesk/php/' . $version . '/bin';
-                if ($this->_dirExists($dir)) {
-                    return $dir;
+            $explicit = $this->_settings->getPhpBinDir();
+            if (!empty($explicit)) {
+                if ($this->_dirExists($explicit)) {
+                    return $explicit;
                 }
+                \pm_Log::warning('xve-laravel-kit: configured PHP bin dir ' . $explicit
+                    . ' does not exist; falling back to auto-detection.');
             }
         } catch (\Throwable $e) {}
 
+        // 2. Detect from the domain's Plesk PHP handler (e.g. plesk-php84-fpm -> 8.4).
+        $handler = '';
         try {
-            $result = $this->_exec('ls -d /opt/plesk/php/*/bin 2>/dev/null | sort -V | tail -1');
-            $dir = trim($result);
-            if (!empty($dir)) {
+            $handler = (string) $this->_domain->getPhpHandlerId();
+        } catch (\Throwable $e) {}
+
+        if ($handler !== '' && preg_match('/php-?(\d)\.?(\d)/i', $handler, $m)) {
+            $version = $m[1] . '.' . $m[2];
+            $dir = '/opt/plesk/php/' . $version . '/bin';
+            if ($this->_dirExists($dir)) {
+                return $dir;
+            }
+            \pm_Log::warning('xve-laravel-kit: PHP handler "' . $handler . '" resolved to '
+                . $version . ' but ' . $dir . ' is missing.');
+        } else {
+            \pm_Log::warning('xve-laravel-kit: could not determine PHP version from handler id "'
+                . $handler . '".');
+        }
+
+        // 3. Last resort: newest installed PHP. This can pick a version the app does
+        //    not support (e.g. a freshly installed 8.5), so make it visible in the log.
+        try {
+            $dir = trim($this->_exec('ls -d /opt/plesk/php/*/bin 2>/dev/null | sort -V | tail -1'));
+            if ($dir !== '') {
+                \pm_Log::warning('xve-laravel-kit: falling back to newest installed PHP (' . $dir
+                    . '). Set an explicit PHP version in the deploy settings if this is wrong.');
                 return $dir;
             }
         } catch (\Throwable $e) {}

--- a/xve-laravel-kit/src/plib/library/Form/Settings.php
+++ b/xve-laravel-kit/src/plib/library/Form/Settings.php
@@ -63,6 +63,18 @@ class Modules_XveLaravelKit_Form_Settings extends pm_Form_Simple
             'description' => 'Controls whether deployment commands (composer, npm, git, artisan) produce output',
         ]);
 
+        $phpVersionOptions = ['auto' => 'Auto-detect from Plesk PHP handler (recommended)'];
+        foreach (Modules_XveLaravelKit_DeploySettings::getAvailablePhpVersions() as $ver => $label) {
+            $phpVersionOptions[$ver] = 'PHP ' . $label;
+        }
+
+        $this->addElement('select', 'php_version', [
+            'label' => 'PHP Version',
+            'value' => $this->_settings->getPhpVersion(),
+            'multiOptions' => $phpVersionOptions,
+            'description' => 'PHP version used for composer and artisan during deploys. "Auto-detect" uses the domain\'s Plesk PHP handler; pin a version if detection picks the wrong one.',
+        ]);
+
         $nodeVersionOptions = ['system' => 'System default'];
         $toolkitVersions = Modules_XveLaravelKit_DeploySettings::getAvailableNodeVersions();
         foreach ($toolkitVersions as $ver => $label) {


### PR DESCRIPTION
## Problem

Deploys ran composer and artisan under the **wrong PHP version**. `Deployer::_getPhpBinDir()` parsed the domain's PHP handler (`plesk-php84` → `8.4`), but on any failure to parse it fell back to:

```
ls -d /opt/plesk/php/*/bin | sort -V | tail -1   # = newest installed PHP
```

On a server with PHP **8.5** installed, an **8.4** site (confirmed: `8.4.22`, FPM served by Apache) had its deploy run under **8.5.7**, failing the platform check for packages capped below 8.5 — e.g. `phpoffice/phpspreadsheet 1.30.2` (`<8.5.0`) and `xve/exactonline-laravel-api v3.0.1` (`^8.3|^8.4`):

```
Your lock file does not contain a compatible set of packages. Please run composer update.
  phpoffice/phpspreadsheet 1.30.2 requires php >=7.4.0 <8.5.0 -> your php version (8.5.7) does not satisfy that requirement.
```

The PATH for every deploy command is `export PATH="$phpBinDir:$PATH"`, so the value `_getPhpBinDir()` returns drives composer/artisan/node entirely.

## Fix

- **New per-domain "PHP Version" deploy setting** (`DeploySettings`, `Form/Settings`, `DomainController`): auto-detect by default, pin a specific version to override detection. Mirrors the existing Node.js version setting.
- **`_getPhpBinDir()` rework**: explicit override → hardened handler-id parse (tolerates `plesk-php8.4` style) → newest-PHP fallback. The fallback (and any failed detection) now logs a `pm_Log::warning`, so a wrong pick is visible in the deploy log and the real handler id is captured.
- Bump `meta.xml` 2.0.2 → 2.0.3, add CHANGELOG entry.

## After merge / install

1. Install v2.0.3 (`dist/xve-laravel-kit-2.0.3.zip` builds from `build.sh`).
2. Set the affected domain's deploy **PHP Version = 8.4** (guarantees correctness even if auto-detect still misbehaves).
3. Re-deploy. If left on auto-detect, the new log line reveals the actual handler id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)