### PR TITLE
fix(deploy): pm_Log::warn not warning (fixes undefined-method crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.4
+
+- Fix deploy crash `Call to undefined method pm_Log::warning()`: Plesk's `pm_Log` exposes `warn()`, not `warning()`. Corrects the v2.0.3 PHP-detection log lines and three pre-existing typos (`TeamsNotifier`, `Task/Deploy`, and a Deployer error path)
+
 ## v2.0.3
 
 - Fix deploy running under the wrong PHP version: `_getPhpBinDir()` no longer silently falls back to the newest installed PHP (e.g. 8.5) when the domain's PHP handler can't be parsed

--- a/xve-laravel-kit/src/meta.xml
+++ b/xve-laravel-kit/src/meta.xml
@@ -4,7 +4,7 @@
     <name>XVE Laravel Kit</name>
     <description>Atomic deployments with rollback, Laravel management tools, .env editor, artisan console, and log viewer. Built for zero-downtime deploys from Git repositories.</description>
     <category>developer</category>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <release>1</release>
     <vendor>XVE BV</vendor>
     <url>https://xve.be</url>

--- a/xve-laravel-kit/src/plib/library/Deployer.php
+++ b/xve-laravel-kit/src/plib/library/Deployer.php
@@ -1113,7 +1113,7 @@ class Modules_XveLaravelKit_Deployer
         if (is_dir($currentLink) && !is_link($currentLink)) {
             $backupName = 'current-backup-' . date('Ymd_His');
             $backupPath = $this->_basePath . '/' . $backupName;
-            \pm_Log::warning(
+            \pm_Log::warn(
                 "switchRelease: 'current' is a real directory, moving to backup: {$backupPath}"
             );
             $this->_exec(sprintf('mv %s %s', escapeshellarg($currentLink), escapeshellarg($backupPath)));
@@ -1469,7 +1469,7 @@ class Modules_XveLaravelKit_Deployer
                 if ($this->_dirExists($explicit)) {
                     return $explicit;
                 }
-                \pm_Log::warning('xve-laravel-kit: configured PHP bin dir ' . $explicit
+                \pm_Log::warn('xve-laravel-kit: configured PHP bin dir ' . $explicit
                     . ' does not exist; falling back to auto-detection.');
             }
         } catch (\Throwable $e) {}
@@ -1486,10 +1486,10 @@ class Modules_XveLaravelKit_Deployer
             if ($this->_dirExists($dir)) {
                 return $dir;
             }
-            \pm_Log::warning('xve-laravel-kit: PHP handler "' . $handler . '" resolved to '
+            \pm_Log::warn('xve-laravel-kit: PHP handler "' . $handler . '" resolved to '
                 . $version . ' but ' . $dir . ' is missing.');
         } else {
-            \pm_Log::warning('xve-laravel-kit: could not determine PHP version from handler id "'
+            \pm_Log::warn('xve-laravel-kit: could not determine PHP version from handler id "'
                 . $handler . '".');
         }
 
@@ -1498,7 +1498,7 @@ class Modules_XveLaravelKit_Deployer
         try {
             $dir = trim($this->_exec('ls -d /opt/plesk/php/*/bin 2>/dev/null | sort -V | tail -1'));
             if ($dir !== '') {
-                \pm_Log::warning('xve-laravel-kit: falling back to newest installed PHP (' . $dir
+                \pm_Log::warn('xve-laravel-kit: falling back to newest installed PHP (' . $dir
                     . '). Set an explicit PHP version in the deploy settings if this is wrong.');
                 return $dir;
             }

--- a/xve-laravel-kit/src/plib/library/Task/Deploy.php
+++ b/xve-laravel-kit/src/plib/library/Task/Deploy.php
@@ -359,7 +359,7 @@ class Modules_XveLaravelKit_Task_Deploy extends pm_LongTask_Task
                 $error
             );
         } catch (\Throwable $e) {
-            pm_Log::warning('Teams notification failed: ' . $e->getMessage());
+            pm_Log::warn('Teams notification failed: ' . $e->getMessage());
         }
     }
 

--- a/xve-laravel-kit/src/plib/library/TeamsNotifier.php
+++ b/xve-laravel-kit/src/plib/library/TeamsNotifier.php
@@ -95,7 +95,7 @@ class Modules_XveLaravelKit_TeamsNotifier
             $output = isset($result['stdout']) ? trim($result['stdout']) : '';
             pm_Log::info('Teams webhook: sent OK — ' . $output);
         } catch (\Throwable $e) {
-            pm_Log::warning('Teams webhook failed: ' . $e->getMessage());
+            pm_Log::warn('Teams webhook failed: ' . $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
## Problem

v2.0.3 deploys crash with:
```
Call to undefined method pm_Log::warning()
```
The PHP-detection log lines I added used `pm_Log::warning()`, but Plesk's `pm_Log` exposes `warn()`, not `warning()` ([API ref](https://plesk.github.io/pm-api-stubs/docs/classes/pm-Log.html)). The crash fires on any deploy path that reaches one of those log lines (e.g. a domain on auto-detect whose handler doesn't parse, or the newest-PHP fallback).

## Fix

`pm_Log::warning` → `pm_Log::warn` across `src/` (7 occurrences). Besides the four v2.0.3 lines in `Deployer::_getPhpBinDir()`, this also corrects three **pre-existing** copies of the same typo that would crash their own error paths: `TeamsNotifier.php`, `Task/Deploy.php`, and a Deployer error branch (line 1116).

Bump `meta.xml` 2.0.3 → 2.0.4 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)