### PR TITLE
Security hardening: webhook, repo allowlist, SSH pinning, no-eval sbin dispatcher (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2.1.0
+
+Security hardening (OPS-25 review). **Breaking:** the webhook no longer accepts the `?secret=` query parameter; callers must send `Authorization: Bearer <secret>`.
+
+- Webhook auth is header-only. Removed the `?secret=` query-string path (it leaked tokens in access/proxy logs and `Referer`); the secret is now read only from `Authorization: Bearer`. The Settings tab shows the token separately for storing in CI secrets
+- Webhook rate limiting: 20 requests per 60s per client IP (`REMOTE_ADDR`), returning HTTP 429 with `Retry-After`; this also throttles secret-guessing
+- Per-domain force gate: a webhook `{"force": true}` (cancel an in-progress deploy) is ignored unless **Allow webhook force-deploy** is enabled for that domain
+- Repository URL allowlist: only SSH URLs to a configured GitHub org (`git@github.com:<your-org>/...`) are accepted, enforced both in the settings form and at deploy time. The allowed orgs are an admin-level extension setting (not hard-coded in this public source); HTTPS and non-listed hosts/owners are rejected
+- SSH host-key pinning: git operations pin GitHub's host keys via a per-domain `known_hosts` with `StrictHostKeyChecking=yes`, replacing the previous `accept-new`
+- Removed the root `eval` wrapper: `sbin/xve-exec.sh` is now an allowlisted argv subcommand dispatcher with no `eval` and no shell interpretation of caller-supplied data; every privileged call site passes its arguments as argv
+
 ## v2.0.4
 
 - Fix deploy crash `Call to undefined method pm_Log::warning()`: Plesk's `pm_Log` exposes `warn()`, not `warning()`. Corrects the v2.0.3 PHP-detection log lines and three pre-existing typos (`TeamsNotifier`, `Task/Deploy`, and a Deployer error path)

--- a/xve-laravel-kit/src/htdocs/public/webhook.php
+++ b/xve-laravel-kit/src/htdocs/public/webhook.php
@@ -1,13 +1,15 @@
 <?php
 /**
- * Public webhook endpoint — no Plesk login required.
+ * Public webhook endpoint -- no Plesk login required.
  *
  * URL: https://<plesk>:8443/modules/xve-laravel-kit/public/webhook.php
  *
  * Usage:
- *   POST ?secret=<token>
  *   POST with Authorization: Bearer <token>
  *   Optional JSON body: {"branch": "main", "force": true}
+ *
+ * Rate limit: 20 requests per 60 seconds per client IP.
+ * On limit exceeded: HTTP 429 with Retry-After header.
  */
 
 // Bootstrap Plesk SDK and extension autoloading
@@ -23,18 +25,29 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     exit;
 }
 
-// Extract secret from query string or Authorization header
-$secret = isset($_GET['secret']) ? $_GET['secret'] : '';
-if (empty($secret)) {
-    $authHeader = isset($_SERVER['HTTP_AUTHORIZATION']) ? $_SERVER['HTTP_AUTHORIZATION'] : '';
-    if (strpos($authHeader, 'Bearer ') === 0) {
-        $secret = substr($authHeader, 7);
-    }
+// Rate limit by client IP before any auth work, so secret-guessing is throttled too.
+// Trust only REMOTE_ADDR -- never X-Forwarded-For for a security decision.
+$clientIp = $_SERVER['REMOTE_ADDR'];
+if (!Modules_XveLaravelKit_RateLimiter::allow($clientIp)) {
+    $retryAfter = Modules_XveLaravelKit_RateLimiter::retryAfter($clientIp);
+    http_response_code(429);
+    header('Retry-After: ' . $retryAfter);
+    echo json_encode(['error' => 'Too many requests. Try again in ' . $retryAfter . ' seconds.']);
+    exit;
+}
+
+// Extract secret from Authorization header only.
+// The ?secret= query-string path has been removed: it leaks tokens in access
+// logs, proxy logs, and Referer headers.
+$secret = '';
+$authHeader = isset($_SERVER['HTTP_AUTHORIZATION']) ? $_SERVER['HTTP_AUTHORIZATION'] : '';
+if (strpos($authHeader, 'Bearer ') === 0) {
+    $secret = substr($authHeader, 7);
 }
 
 if (empty($secret)) {
     http_response_code(401);
-    echo json_encode(['error' => 'Missing secret. Pass as ?secret=... or Authorization: Bearer header.']);
+    echo json_encode(['error' => 'Missing or invalid Authorization header. Use: Authorization: Bearer <token>']);
     exit;
 }
 
@@ -62,9 +75,17 @@ if (!empty($body)) {
     }
 }
 
-// Concurrency guard — cancel or reject depending on force flag
+// Concurrency guard -- cancel or reject depending on force flag and domain config
 if (Modules_XveLaravelKit_Task_Deploy::isLocked($domain->getId())) {
     if ($force) {
+        if (!$settings->isWebhookForceAllowed()) {
+            http_response_code(409);
+            echo json_encode([
+                'error'  => 'Force-deploy is disabled for this domain. Enable it in the XVE Laravel Kit settings for this domain.',
+                'domain' => $domain->getDisplayName(),
+            ]);
+            exit;
+        }
         Modules_XveLaravelKit_Task_Deploy::cancelRunning($domain->getId());
     } else {
         http_response_code(409);

--- a/xve-laravel-kit/src/meta.xml
+++ b/xve-laravel-kit/src/meta.xml
@@ -4,7 +4,7 @@
     <name>XVE Laravel Kit</name>
     <description>Atomic deployments with rollback, Laravel management tools, .env editor, artisan console, and log viewer. Built for zero-downtime deploys from Git repositories.</description>
     <category>developer</category>
-    <version>2.0.4</version>
+    <version>2.1.0</version>
     <release>1</release>
     <vendor>XVE BV</vendor>
     <url>https://xve.be</url>

--- a/xve-laravel-kit/src/plib/controllers/DomainController.php
+++ b/xve-laravel-kit/src/plib/controllers/DomainController.php
@@ -182,7 +182,8 @@ class DomainController extends pm_Controller_Action
         $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
         $host = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? 'localhost';
         $this->view->webhookUrl = $scheme . '://' . $host
-            . '/modules/xve-laravel-kit/public/webhook.php?secret=' . $secret;
+            . '/modules/xve-laravel-kit/public/webhook.php';
+        $this->view->webhookSecret = $secret;
 
         $this->view->hasComposerAuth = $this->_deployer->hasComposerAuth();
         $this->view->wwwRootSet = $this->_settings->isWwwRootSet();
@@ -202,6 +203,7 @@ class DomainController extends pm_Controller_Action
                 $this->_settings->setStepEnabled($step, (bool) $form->getValue('step_' . $step));
             }
             $this->_settings->setTeamsNotifyEnabled((bool) $form->getValue('teams_notify'));
+            $this->_settings->setWebhookForceAllowed((bool) $form->getValue('webhook_allow_force'));
             $this->_settings->setKeepReleases((int) $form->getValue('keep_releases'));
             $this->_settings->setHealthCheckUrl($form->getValue('health_check_url'));
             $this->_settings->setHealthCheckTimeout((int) $form->getValue('health_check_timeout'));

--- a/xve-laravel-kit/src/plib/controllers/IndexController.php
+++ b/xve-laravel-kit/src/plib/controllers/IndexController.php
@@ -15,6 +15,10 @@ class IndexController extends pm_Controller_Action
         if ($this->getRequest()->isPost()) {
             $webhookUrl = trim($this->getRequest()->getParam('teams_webhook_url', ''));
             Modules_XveLaravelKit_TeamsNotifier::setWebhookUrl($webhookUrl);
+
+            $allowedOwners = $this->getRequest()->getParam('allowed_repo_owners', '');
+            Modules_XveLaravelKit_DeploySettings::setAllowedRepoOwners($allowedOwners);
+
             $this->_status->addMessage('info', 'Settings saved.');
 
             $url = Modules_XveLaravelKit_Url::action('index/settings');
@@ -23,6 +27,7 @@ class IndexController extends pm_Controller_Action
         }
 
         $this->view->teamsWebhookUrl = Modules_XveLaravelKit_TeamsNotifier::getWebhookUrl();
+        $this->view->allowedRepoOwners = implode("\n", Modules_XveLaravelKit_DeploySettings::getAllowedRepoOwners());
     }
 
     public function guideAction()
@@ -79,14 +84,7 @@ class IndexController extends pm_Controller_Action
         // 1. Create Plesk subscription
         try {
             $ip = $this->_getServerIp();
-            $cmd = sprintf(
-                'plesk bin subscription --create %s -owner admin -login %s -passwd %s -ip %s -hosting true 2>&1',
-                escapeshellarg($domainName),
-                escapeshellarg($login),
-                escapeshellarg($password),
-                escapeshellarg($ip)
-            );
-            pm_ApiCli::callSbin('xve-exec.sh', [$cmd]);
+            pm_ApiCli::callSbin('xve-exec.sh', ['plesk-subscription-create', $domainName, $login, $password, $ip]);
         } catch (\Throwable $e) {
             $this->_status->addMessage('error', 'Failed to create subscription: ' . $e->getMessage());
             $url = Modules_XveLaravelKit_Url::action('index/index');

--- a/xve-laravel-kit/src/plib/library/DeploySettings.php
+++ b/xve-laravel-kit/src/plib/library/DeploySettings.php
@@ -128,6 +128,16 @@ class Modules_XveLaravelKit_DeploySettings
 
     // -- Webhook --
 
+    public function isWebhookForceAllowed()
+    {
+        return (bool) pm_Settings::get($this->_prefix . 'webhook_allow_force', false);
+    }
+
+    public function setWebhookForceAllowed($value)
+    {
+        pm_Settings::set($this->_prefix . 'webhook_allow_force', $value ? '1' : '0');
+    }
+
     public function getWebhookSecret()
     {
         $secret = pm_Settings::get($this->_prefix . 'webhook_secret', '');
@@ -401,6 +411,67 @@ class Modules_XveLaravelKit_DeploySettings
         return $this->getSshKeyDir() . '/id_ed25519.pub';
     }
 
+    // -- Repo URL allowlist --
+    // Only SSH URLs to an admin-configured GitHub org are permitted (security:
+    // trusted repos only). The allowed orgs are an extension-level setting so the
+    // list is never hard-coded in this (public) source tree.
+    const ALLOWED_REPO_HOST = 'github.com';
+    const SETTING_ALLOWED_REPO_OWNERS = 'xlk_allowed_repo_owners';
+
+    /**
+     * The GitHub orgs/owners allowed as deploy sources, configured by an admin in
+     * the extension settings. Stored newline/comma-separated; returns a trimmed
+     * list with empties removed. Empty when nothing has been configured yet.
+     */
+    public static function getAllowedRepoOwners()
+    {
+        $raw = pm_Settings::get(self::SETTING_ALLOWED_REPO_OWNERS, '');
+        $owners = preg_split('/[\s,]+/', (string) $raw, -1, PREG_SPLIT_NO_EMPTY);
+        return array_values(array_unique(array_map('trim', $owners)));
+    }
+
+    public static function setAllowedRepoOwners($value)
+    {
+        pm_Settings::set(self::SETTING_ALLOWED_REPO_OWNERS, trim((string) $value));
+    }
+
+    /**
+     * Validate a git repository URL against the allowlist.
+     * Accepts only scp-style SSH URLs to an allowed owner on the allowed host:
+     *   git@github.com:<allowed-owner>/<repo>(.git)
+     * Rejects HTTPS, other hosts, other owners, traversal, and malformed input.
+     * Fails closed: when no owner has been configured, every URL is rejected.
+     */
+    public static function validateRepoUrl($url)
+    {
+        if (!is_string($url)) {
+            return false;
+        }
+        $url = trim($url);
+        if ($url === '' || strpos($url, "\0") !== false) {
+            return false;
+        }
+        // scp-style: git@HOST:OWNER/REPO(.git)
+        if (!preg_match('#^git@([^:/]+):([^/]+)/([A-Za-z0-9._-]+?)(?:\.git)?$#', $url, $m)) {
+            return false;
+        }
+        $host = $m[1];
+        $owner = $m[2];
+        $repo = $m[3];
+        if ($host !== self::ALLOWED_REPO_HOST) {
+            return false;
+        }
+        $allowedOwners = self::getAllowedRepoOwners();
+        if (empty($allowedOwners) || !in_array($owner, $allowedOwners, true)) {
+            return false;
+        }
+        // repo name must not be empty, '.' or '..'
+        if ($repo === '' || $repo === '.' || $repo === '..') {
+            return false;
+        }
+        return true;
+    }
+
     public function isSshRepo()
     {
         $repo = $this->getGitRepo();
@@ -511,7 +582,7 @@ class Modules_XveLaravelKit_DeploySettings
             'health_check_url', 'health_check_timeout',
             'pre_deploy_script', 'post_deploy_script',
             'current_release', 'last_deploy_time', 'last_deploy_status',
-            'webhook_secret', 'shared_dirs', 'shared_files', 'node_pm', 'node_version', 'deploy_mode', 'teams_notify',
+            'webhook_secret', 'webhook_allow_force', 'shared_dirs', 'shared_files', 'node_pm', 'node_version', 'deploy_mode', 'teams_notify',
             'www_root_set',
         ];
         foreach ($keys as $key) {

--- a/xve-laravel-kit/src/plib/library/Deployer.php
+++ b/xve-laravel-kit/src/plib/library/Deployer.php
@@ -107,13 +107,8 @@ class Modules_XveLaravelKit_Deployer
 
         // Recursive ownership + permissions on shared/ so Laravel can write
         $sharedPath = $this->_basePath . '/shared';
-        $this->_exec(sprintf('chown -R %s:%s %s',
-            escapeshellarg($user),
-            escapeshellarg($group),
-            escapeshellarg($sharedPath)
-        ));
-        $this->_exec(sprintf('find %s -type d -exec chmod 775 {} +', escapeshellarg($sharedPath)));
-        $this->_exec(sprintf('find %s -type f -exec chmod 664 {} +', escapeshellarg($sharedPath)));
+        $this->_sbin('chown-r', [$user, $group, $sharedPath]);
+        $this->_sbin('fix-shared-perms', [$sharedPath]);
 
         // Set Plesk document root to current/public (current is a symlink to the active release)
         if ($setWwwRoot) {
@@ -129,9 +124,7 @@ class Modules_XveLaravelKit_Deployer
     public function setWwwRoot()
     {
         $domainName = $this->_domain->getDisplayName();
-        $this->_exec(sprintf('plesk bin site --update %s -www-root current/public',
-            escapeshellarg($domainName)
-        ));
+        $this->_sbin('plesk-site-wwwroot', [$domainName, 'current/public']);
         $this->_settings->setWwwRootSet(true);
     }
 
@@ -146,26 +139,20 @@ class Modules_XveLaravelKit_Deployer
         // Reset Plesk document root back to httpdocs
         $domainName = $this->_domain->getDisplayName();
         try {
-            $this->_exec(sprintf('plesk bin site --update %s -www-root httpdocs',
-                escapeshellarg($domainName)
-            ));
+            $this->_sbin('plesk-site-wwwroot', [$domainName, 'httpdocs']);
         } catch (\Throwable $e) {}
 
         // Remove current symlink
-        $this->_exec('rm -f ' . escapeshellarg($this->_basePath . '/current'));
-        $this->_exec('rm -f ' . escapeshellarg($this->_basePath . '/artisan'));
-        $this->_exec('rm -f ' . escapeshellarg($this->_basePath . '/' . self::HISTORY_FILE));
+        $this->_sbin('rm-f', [$this->_basePath . '/current']);
+        $this->_sbin('rm-f', [$this->_basePath . '/artisan']);
+        $this->_sbin('rm-f', [$this->_basePath . '/' . self::HISTORY_FILE]);
 
         // Ensure httpdocs exists so Plesk has a valid document root
         $httpdocs = $this->_basePath . '/httpdocs';
         if (!$this->_dirExists($httpdocs)) {
-            $this->_exec('mkdir -p ' . escapeshellarg($httpdocs));
+            $this->_sbin('mkdir-p', [$httpdocs]);
             $user = $this->_getSystemUser();
-            $this->_exec(sprintf('chown %s:%s %s',
-                escapeshellarg($user),
-                escapeshellarg('psaserv'),
-                escapeshellarg($httpdocs)
-            ));
+            $this->_sbin('chown', [$user, 'psaserv', $httpdocs]);
         }
 
         // Archive shared/ before deletion so .env, uploads, and logs can be recovered
@@ -176,20 +163,16 @@ class Modules_XveLaravelKit_Deployer
         if ($this->_dirExists($sharedPath)) {
             $sharedArchive = $this->_basePath . '/shared-teardown-' . $timestamp . '.tar.gz';
             try {
-                $this->_exec(sprintf(
-                    'tar -czf %s -C %s shared',
-                    escapeshellarg($sharedArchive),
-                    escapeshellarg($this->_basePath)
-                ));
+                $this->_sbin('tar-czf-shared', [$sharedArchive, $this->_basePath]);
                 \pm_Log::info('Teardown: shared/ backed up to ' . $sharedArchive);
             } catch (\Throwable $e) {
-                \pm_Log::info('Teardown: could not archive shared/ — ' . $e->getMessage());
+                \pm_Log::info('Teardown: could not archive shared/ - ' . $e->getMessage());
             }
         }
 
         // Remove releases and shared (releases are re-deployable from git, so no backup needed)
-        $this->_exec('rm -rf ' . escapeshellarg($this->_basePath . '/releases'));
-        $this->_exec('rm -rf ' . escapeshellarg($this->_basePath . '/shared'));
+        $this->_sbin('rm-rf', [$this->_basePath . '/releases']);
+        $this->_sbin('rm-rf', [$this->_basePath . '/shared']);
     }
 
     // ─── Deploy ────────────────────────────────────────────────
@@ -284,7 +267,7 @@ class Modules_XveLaravelKit_Deployer
         }
 
         try {
-            $output = $this->_exec('ls -1r ' . escapeshellarg($releasesDir) . ' 2>/dev/null');
+            $output = $this->_sbin('ls-1r', [$releasesDir]);
         } catch (\Throwable $e) {
             return [];
         }
@@ -346,10 +329,10 @@ class Modules_XveLaravelKit_Deployer
         foreach ($releases as $release) {
             // Only remove releases explicitly marked as 'failed' in the deploy history.
             // Successful and rollback releases are kept so that _cleanup() / keepReleases
-            // can prune them in a controlled way — preserving rollback capability.
+            // can prune them in a controlled way, preserving rollback capability.
             if (!$release['current'] && in_array($release['status'], ['failed', 'unknown'], true)) {
                 $path = $this->_basePath . '/releases/' . $release['name'];
-                $this->_exec('rm -rf ' . escapeshellarg($path));
+                $this->_sbin('rm-rf', [$path]);
                 $removed++;
             }
         }
@@ -417,7 +400,7 @@ class Modules_XveLaravelKit_Deployer
         try {
             $phpBinDir = $this->_getPhpBinDir();
             $phpBin = $phpBinDir ? $phpBinDir . '/php' : 'php';
-            $info['php_version'] = trim($this->_exec($phpBin . ' -r "echo PHP_VERSION;" 2>/dev/null'));
+            $info['php_version'] = trim($this->_sbin('php-version', [$phpBin]));
         } catch (\Throwable $e) {}
 
         // .env values
@@ -497,15 +480,15 @@ class Modules_XveLaravelKit_Deployer
         $this->_fileManager->filePutContents($path, $contents);
 
         $user = $this->_getSystemUser();
-        $this->_exec(sprintf('chown %s:psaserv %s', escapeshellarg($user), escapeshellarg($path)));
-        $this->_exec(sprintf('chmod 600 %s', escapeshellarg($path)));
+        $this->_sbin('chown', [$user, 'psaserv', $path]);
+        $this->_sbin('chmod', ['600', $path]);
     }
 
     public function deleteComposerAuth()
     {
         $path = $this->getComposerAuthPath();
         if ($this->_fileManager->fileExists($path)) {
-            $this->_exec('rm -f ' . escapeshellarg($path));
+            $this->_sbin('rm-f', [$path]);
         }
     }
 
@@ -615,7 +598,7 @@ class Modules_XveLaravelKit_Deployer
         try {
             if ($this->_fileManager->fileExists($envPath)) {
                 $backup = $this->_basePath . '/shared/.env.backup.' . date('Ymd_His');
-                $this->_exec(sprintf('cp %s %s', escapeshellarg($envPath), escapeshellarg($backup)));
+                $this->_sbin('cp', [$envPath, $backup]);
             }
         } catch (\Throwable $e) {}
 
@@ -627,7 +610,7 @@ class Modules_XveLaravelKit_Deployer
                 sort($backups);
                 $excess = array_slice($backups, 0, count($backups) - 10);
                 foreach ($excess as $old) {
-                    $this->_exec('rm -f ' . escapeshellarg($old));
+                    $this->_sbin('rm-f', [$old]);
                 }
             }
         } catch (\Throwable $e) {}
@@ -636,11 +619,7 @@ class Modules_XveLaravelKit_Deployer
 
         // Chown to system user
         $user = $this->_getSystemUser();
-        $this->_exec(sprintf('chown %s:%s %s',
-            escapeshellarg($user),
-            escapeshellarg('psaserv'),
-            escapeshellarg($envPath)
-        ));
+        $this->_sbin('chown', [$user, 'psaserv', $envPath]);
     }
 
     /**
@@ -717,15 +696,17 @@ class Modules_XveLaravelKit_Deployer
         }
 
         $phpBinDir = $this->_getPhpBinDir();
-        $pathExport = $phpBinDir ? 'export PATH="' . $phpBinDir . ':$PATH" && ' : '';
+        $pathExport = $phpBinDir ? 'export PATH="' . $phpBinDir . ':$PATH"' . "\n" : '';
 
         try {
-            $fullCmd = sprintf(
-                'su -s /bin/bash %s -c %s 2>&1',
-                escapeshellarg($this->_getSystemUser()),
-                escapeshellarg($pathExport . 'cd ' . escapeshellarg($currentPath) . ' && php artisan ' . $command)
+            $scriptPath = $currentPath . '/.xve-artisan-' . uniqid() . '.sh';
+            $this->_fileManager->filePutContents(
+                $scriptPath,
+                "#!/bin/bash\nset -euo pipefail\n" . $pathExport . 'cd ' . escapeshellarg($currentPath) . ' && php artisan ' . $command . "\n"
             );
-            $output = $this->_exec($fullCmd);
+            $this->_sbin('chmod', ['+x', $scriptPath]);
+            $output = $this->_sbin('run-script-as-user', [$this->_getSystemUser(), $scriptPath]);
+            $this->_sbin('rm-f', [$scriptPath]);
             return ['success' => true, 'output' => $output];
         } catch (\Throwable $e) {
             return ['success' => false, 'output' => $e->getMessage()];
@@ -742,7 +723,7 @@ class Modules_XveLaravelKit_Deployer
             if (!$this->_fileManager->fileExists($logPath)) {
                 return '';
             }
-            $output = $this->_exec(sprintf('tail -n %d %s 2>/dev/null', (int) $lines, escapeshellarg($logPath)));
+            $output = $this->_sbin('tail-n', [(string)(int)$lines, $logPath]);
             return $output;
         } catch (\Throwable $e) {
             return 'Error reading log: ' . $e->getMessage();
@@ -757,7 +738,7 @@ class Modules_XveLaravelKit_Deployer
         $logPath = $this->_basePath . '/shared/storage/logs/laravel.log';
         try {
             if ($this->_fileManager->fileExists($logPath)) {
-                $this->_exec('truncate -s 0 ' . escapeshellarg($logPath));
+                $this->_sbin('truncate0', [$logPath]);
             }
             return true;
         } catch (\Throwable $e) {
@@ -795,7 +776,7 @@ class Modules_XveLaravelKit_Deployer
         }
         $pathPrefix = !empty($pathDirs) ? 'export PATH="' . implode(':', $pathDirs) . ':$PATH" && ' : '';
 
-        $checks['git'] = $this->_checkTool('git', 'git --version');
+        $checks['git'] = $this->_checkGitTool();
         $checks['php'] = $this->_checkToolAsUser($user, $pathPrefix . 'php --version | head -1');
         $checks['composer'] = $this->_checkToolAsUser($user, $pathPrefix . 'composer --version 2>&1 | head -1');
         $checks['node'] = $this->_checkToolAsUser($user, $pathPrefix . 'node --version 2>&1');
@@ -816,7 +797,7 @@ class Modules_XveLaravelKit_Deployer
 
         $basePathOk = false;
         try {
-            $result = $this->_exec('test -d ' . escapeshellarg($this->_basePath) . ' && test -w ' . escapeshellarg($this->_basePath) . ' && echo "yes" || echo "no"');
+            $result = $this->_sbin('test-dir-writable', [$this->_basePath]);
             $basePathOk = trim($result) === 'yes';
         } catch (\Throwable $e) {}
         $checks['base_path'] = [
@@ -856,10 +837,7 @@ class Modules_XveLaravelKit_Deployer
     {
         try {
             $domainId = $this->_domain->getId();
-            $output = $this->_exec(sprintf(
-                'plesk db "SELECT db.name, du.login FROM data_bases db LEFT JOIN db_users du ON du.db_id = db.id WHERE db.dom_id = %d LIMIT 1"',
-                (int) $domainId
-            ));
+            $output = $this->_sbin('detect-db', [(string) (int) $domainId]);
             $output = trim($output);
             if (empty($output)) {
                 return null;
@@ -904,12 +882,8 @@ class Modules_XveLaravelKit_Deployer
 
         foreach ($paths as $path) {
             if (!$this->_fileManager->fileExists($path)) {
-                $this->_exec('mkdir -p ' . escapeshellarg($path));
-                $this->_exec(sprintf('chown -R %s:%s %s',
-                    escapeshellarg($user),
-                    escapeshellarg('psaserv'),
-                    escapeshellarg($path)
-                ));
+                $this->_sbin('mkdir-p', [$path]);
+                $this->_sbin('chown-r', [$user, 'psaserv', $path]);
             }
         }
     }
@@ -921,18 +895,13 @@ class Modules_XveLaravelKit_Deployer
             return [];
         }
 
-        $envPrefix = '';
-        if ($this->_settings->isSshRepo()) {
-            Modules_XveLaravelKit_SshKey::ensure($this->_settings);
-            $keyPath = $this->_settings->getSshPrivateKeyPath();
-            $envPrefix = sprintf(
-                'GIT_SSH_COMMAND=%s ',
-                escapeshellarg('ssh -i ' . $keyPath . ' -o StrictHostKeyChecking=accept-new')
-            );
+        if (!Modules_XveLaravelKit_DeploySettings::validateRepoUrl($repo)) {
+            return [];
         }
 
-        $cmd = sprintf('%sgit ls-remote --heads %s 2>&1', $envPrefix, escapeshellarg($repo));
-        $output = $this->_exec($cmd);
+        $key = $this->_settings->getSshPrivateKeyPath();
+        $knownHosts = Modules_XveLaravelKit_SshKey::ensureKnownHosts($this->_settings);
+        $output = $this->_sbin('git-ls-remote', [$key, $knownHosts, $repo]);
 
         $branches = [];
         foreach (explode("\n", trim($output)) as $line) {
@@ -956,46 +925,27 @@ class Modules_XveLaravelKit_Deployer
             return '';
         }
 
-        $envPrefix = '';
-        if ($this->_settings->isSshRepo()) {
-            Modules_XveLaravelKit_SshKey::ensure($this->_settings);
-            $keyPath = $this->_settings->getSshPrivateKeyPath();
-            $envPrefix = sprintf(
-                'GIT_SSH_COMMAND=%s ',
-                escapeshellarg('ssh -i ' . $keyPath . ' -o StrictHostKeyChecking=accept-new')
-            );
+        if (!Modules_XveLaravelKit_DeploySettings::validateRepoUrl($repo)) {
+            return '';
         }
 
+        $key = $this->_settings->getSshPrivateKeyPath();
+        $knownHosts = Modules_XveLaravelKit_SshKey::ensureKnownHosts($this->_settings);
+
         try {
-            $cmd = sprintf(
-                '%sgit archive --remote=%s %s %s 2>/dev/null | tar -xO %s 2>/dev/null',
-                $envPrefix,
-                escapeshellarg($repo),
-                escapeshellarg($branch),
-                escapeshellarg($filePath),
-                escapeshellarg($filePath)
-            );
-            return $this->_exec($cmd);
+            return $this->_sbin('git-archive-file', [$key, $knownHosts, $repo, $branch, $filePath]);
         } catch (\Throwable $e) {
             // git archive may not be supported (e.g. GitHub), try shallow clone fallback
+            $tmpDir = '/tmp/xlk-init-' . uniqid();
             try {
-                $tmpDir = '/tmp/xlk-init-' . uniqid();
-                $cloneCmd = sprintf(
-                    '%sgit clone --depth 1 --quiet --branch %s --no-checkout %s %s 2>&1 && git -C %s checkout HEAD -- %s 2>&1',
-                    $envPrefix,
-                    escapeshellarg($branch),
-                    escapeshellarg($repo),
-                    escapeshellarg($tmpDir),
-                    escapeshellarg($tmpDir),
-                    escapeshellarg($filePath)
-                );
-                $this->_exec($cloneCmd);
+                $quiet = ($this->_settings->getDeployMode() === 'quiet') ? '1' : '0';
+                $this->_sbin('git-clone-file', [$key, $knownHosts, $quiet, $branch, $repo, $tmpDir, $filePath]);
                 $contents = $this->_fileManager->fileGetContents($tmpDir . '/' . $filePath);
-                $this->_exec('rm -rf ' . escapeshellarg($tmpDir));
+                $this->_sbin('rm-rf', [$tmpDir]);
                 return $contents;
             } catch (\Throwable $e2) {
-                // Cleanup and return empty — file may not exist in repo
-                try { $this->_exec('rm -rf ' . escapeshellarg($tmpDir)); } catch (\Throwable $e3) {}
+                // Cleanup and return empty; file may not exist in repo
+                try { $this->_sbin('rm-rf', [$tmpDir]); } catch (\Throwable $e3) {}
                 return '';
             }
         }
@@ -1006,40 +956,26 @@ class Modules_XveLaravelKit_Deployer
         $repo = $this->_settings->getGitRepo();
         $branch = $branchOverride ?: $this->_settings->getBranch();
 
-        $envPrefix = '';
-        if ($this->_settings->isSshRepo()) {
-            Modules_XveLaravelKit_SshKey::ensure($this->_settings);
-            $keyPath = $this->_settings->getSshPrivateKeyPath();
-            $envPrefix = sprintf(
-                'GIT_SSH_COMMAND=%s ',
-                escapeshellarg('ssh -i ' . $keyPath . ' -o StrictHostKeyChecking=accept-new')
-            );
+        if (!Modules_XveLaravelKit_DeploySettings::validateRepoUrl($repo)) {
+            throw new pm_Exception('Refusing to deploy: repository URL is not on the allowlist (a configured GitHub org over SSH only): ' . $repo);
         }
 
-        $mode = $this->_settings->getDeployMode();
-        $q = ($mode === 'quiet') ? ' --quiet' : '';
+        $key = $this->_settings->getSshPrivateKeyPath();
+        $knownHosts = Modules_XveLaravelKit_SshKey::ensureKnownHosts($this->_settings);
+        $quiet = ($this->_settings->getDeployMode() === 'quiet') ? '1' : '0';
 
-        $cmd = sprintf(
-            '%sgit clone --depth 1%s --branch %s %s %s 2>&1',
-            $envPrefix,
-            $q,
-            escapeshellarg($branch),
-            escapeshellarg($repo),
-            escapeshellarg($releasePath)
-        );
-
-        $output = $this->_exec($cmd);
+        $output = $this->_sbin('git-clone', [$key, $knownHosts, $quiet, $branch, $repo, $releasePath]);
 
         if (!$this->_dirExists($releasePath . '/.git')) {
             throw new pm_Exception('Git clone failed: ' . $output);
         }
 
         // Capture commit info before removing .git
-        $commitHash = trim($this->_exec('git -C ' . escapeshellarg($releasePath) . ' rev-parse HEAD 2>/dev/null'));
-        $commitMsg = trim($this->_exec('git -C ' . escapeshellarg($releasePath) . ' log -1 --pretty=%s 2>/dev/null'));
-        $commitAuthor = trim($this->_exec('git -C ' . escapeshellarg($releasePath) . ' log -1 --pretty=%an 2>/dev/null'));
+        $commitHash = trim($this->_sbin('git-rev-parse', [$releasePath]));
+        $commitMsg = trim($this->_sbin('git-log', [$releasePath, '%s']));
+        $commitAuthor = trim($this->_sbin('git-log', [$releasePath, '%an']));
 
-        $this->_exec('rm -rf ' . escapeshellarg($releasePath . '/.git'));
+        $this->_sbin('rm-rf', [$releasePath . '/.git']);
 
         return [
             'hash' => $commitHash,
@@ -1058,18 +994,14 @@ class Modules_XveLaravelKit_Deployer
             $shared = $this->_basePath . '/shared/' . $dir;
             $parentDir = dirname($target);
             if ($parentDir !== $releasePath) {
-                $this->_exec('mkdir -p ' . escapeshellarg($parentDir));
+                $this->_sbin('mkdir-p', [$parentDir]);
             }
             if (!$this->_fileManager->fileExists($shared)) {
-                $this->_exec('mkdir -p ' . escapeshellarg($shared));
-                $this->_exec(sprintf('chown -R %s:%s %s',
-                    escapeshellarg($user),
-                    escapeshellarg('psaserv'),
-                    escapeshellarg($shared)
-                ));
+                $this->_sbin('mkdir-p', [$shared]);
+                $this->_sbin('chown-r', [$user, 'psaserv', $shared]);
             }
-            $this->_exec('rm -rf ' . escapeshellarg($target));
-            $this->_exec(sprintf('ln -sfn %s %s', escapeshellarg($shared), escapeshellarg($target)));
+            $this->_sbin('rm-rf', [$target]);
+            $this->_sbin('ln-sfn', [$shared, $target]);
         }
 
         foreach ($this->_settings->getSharedFiles() as $file) {
@@ -1079,17 +1011,13 @@ class Modules_XveLaravelKit_Deployer
             if ($this->_fileManager->fileExists($shared)) {
                 $parentDir = dirname($target);
                 if ($parentDir !== $releasePath) {
-                    $this->_exec('mkdir -p ' . escapeshellarg($parentDir));
+                    $this->_sbin('mkdir-p', [$parentDir]);
                 }
-                $this->_exec('rm -f ' . escapeshellarg($target));
-                $this->_exec(sprintf('ln -sfn %s %s', escapeshellarg($shared), escapeshellarg($target)));
+                $this->_sbin('rm-f', [$target]);
+                $this->_sbin('ln-sfn', [$shared, $target]);
             } elseif (!$this->_fileManager->fileExists($sharedParentDir)) {
-                $this->_exec('mkdir -p ' . escapeshellarg($sharedParentDir));
-                $this->_exec(sprintf('chown -R %s:%s %s',
-                    escapeshellarg($user),
-                    escapeshellarg('psaserv'),
-                    escapeshellarg($sharedParentDir)
-                ));
+                $this->_sbin('mkdir-p', [$sharedParentDir]);
+                $this->_sbin('chown-r', [$user, 'psaserv', $sharedParentDir]);
             }
         }
 
@@ -1097,8 +1025,8 @@ class Modules_XveLaravelKit_Deployer
         $authJson = $this->_basePath . '/shared/auth.json';
         if ($this->_fileManager->fileExists($authJson)) {
             $target = $releasePath . '/auth.json';
-            $this->_exec('rm -f ' . escapeshellarg($target));
-            $this->_exec(sprintf('ln -sfn %s %s', escapeshellarg($authJson), escapeshellarg($target)));
+            $this->_sbin('rm-f', [$target]);
+            $this->_sbin('ln-sfn', [$authJson, $target]);
         }
     }
 
@@ -1116,7 +1044,7 @@ class Modules_XveLaravelKit_Deployer
             \pm_Log::warn(
                 "switchRelease: 'current' is a real directory, moving to backup: {$backupPath}"
             );
-            $this->_exec(sprintf('mv %s %s', escapeshellarg($currentLink), escapeshellarg($backupPath)));
+            $this->_sbin('mv', [$currentLink, $backupPath]);
 
             // Keep only the last 2 current-backup-* directories to avoid unbounded growth
             $backupList = glob($this->_basePath . '/current-backup-*', GLOB_ONLYDIR);
@@ -1124,19 +1052,19 @@ class Modules_XveLaravelKit_Deployer
                 sort($backupList);
                 $toDelete = array_slice($backupList, 0, max(0, count($backupList) - 2));
                 foreach ($toDelete as $old) {
-                    $this->_exec('rm -rf ' . escapeshellarg($old));
+                    $this->_sbin('rm-rf', [$old]);
                 }
             }
         }
 
         // Atomic symlink switch: create temp link, then rename over current
-        $this->_exec(sprintf('ln -sfn %s %s', escapeshellarg($releasePath), escapeshellarg($tempLink)));
-        $this->_exec(sprintf('mv -Tf %s %s', escapeshellarg($tempLink), escapeshellarg($currentLink)));
+        $this->_sbin('ln-sfn', [$releasePath, $tempLink]);
+        $this->_sbin('mv-tf', [$tempLink, $currentLink]);
 
         // Fix symlink ownership — nginx's disable_symlinks if_not_owner
         // requires the symlink itself to be owned by the domain user
         $user = $this->_getSystemUser();
-        $this->_exec(sprintf('chown -h %s:psaserv %s', escapeshellarg($user), escapeshellarg($currentLink)));
+        $this->_sbin('chown-h', [$user, 'psaserv', $currentLink]);
     }
 
     private function _ensureArtisanSymlink()
@@ -1144,7 +1072,7 @@ class Modules_XveLaravelKit_Deployer
         $artisanLink = $this->_basePath . '/artisan';
         $target = 'current/artisan';
         if ($this->_fileManager->fileExists($this->_basePath . '/current/artisan')) {
-            $this->_exec(sprintf('ln -sfn %s %s', escapeshellarg($target), escapeshellarg($artisanLink)));
+            $this->_sbin('ln-sfn', [$target, $artisanLink]);
         }
     }
 
@@ -1153,11 +1081,11 @@ class Modules_XveLaravelKit_Deployer
         $publicStorage = $releasePath . '/public/storage';
         $target = $this->_basePath . '/shared/storage/app/public';
         if ($this->_dirExists($target) && !$this->_fileManager->fileExists($publicStorage)) {
-            $this->_exec(sprintf('ln -sfn %s %s', escapeshellarg($target), escapeshellarg($publicStorage)));
-            // chown the symlink itself — nginx disable_symlinks if_not_owner
+            $this->_sbin('ln-sfn', [$target, $publicStorage]);
+            // chown the symlink itself; nginx disable_symlinks if_not_owner
             // requires the symlink owner to match the target owner
             $user = $this->_getSystemUser();
-            $this->_exec(sprintf('chown -h %s:psaserv %s', escapeshellarg($user), escapeshellarg($publicStorage)));
+            $this->_sbin('chown-h', [$user, 'psaserv', $publicStorage]);
         }
     }
 
@@ -1183,24 +1111,12 @@ class Modules_XveLaravelKit_Deployer
             throw new pm_Exception('Health check URL must be on the same domain.');
         }
 
-        $cmd = sprintf(
-            // -L follows redirects as a safety net (e.g. http -> https redirects).
-            'curl -sfL --max-time %d -o /dev/null -w "%%{http_code}" %s 2>&1',
-            (int) $timeout,
-            escapeshellarg($url)
-        );
-
-        $httpCode = trim($this->_exec($cmd));
+        $httpCode = trim($this->_sbin('curl-health', [(string)(int)$timeout, $url]));
         $code = (int) $httpCode;
 
         if (($code < 200 || $code >= 400) && $autoHttps) {
             $url = str_replace('https://', 'http://', $url);
-            $cmd = sprintf(
-                'curl -sfL --max-time %d -o /dev/null -w "%%{http_code}" %s 2>&1',
-                (int) $timeout,
-                escapeshellarg($url)
-            );
-            $httpCode = trim($this->_exec($cmd));
+            $httpCode = trim($this->_sbin('curl-health', [(string)(int)$timeout, $url]));
             $code = (int) $httpCode;
         }
 
@@ -1232,15 +1148,11 @@ class Modules_XveLaravelKit_Deployer
         $this->_fileManager->filePutContents($scriptPath,
             "#!/bin/bash\nset -euo pipefail\n" . $pathExport . "cd " . escapeshellarg($releasePath) . "\n" . $script
         );
-        $this->_exec('chmod +x ' . escapeshellarg($scriptPath));
+        $this->_sbin('chmod', ['+x', $scriptPath]);
 
-        $output = $this->_exec(sprintf(
-            'su -s /bin/bash %s -c %s 2>&1',
-            escapeshellarg($this->_getSystemUser()),
-            escapeshellarg('bash ' . $scriptPath)
-        ));
+        $output = $this->_sbin('run-script-as-user', [$this->_getSystemUser(), $scriptPath]);
 
-        $this->_exec('rm -f ' . escapeshellarg($scriptPath));
+        $this->_sbin('rm-f', [$scriptPath]);
 
         return $output;
     }
@@ -1335,7 +1247,7 @@ class Modules_XveLaravelKit_Deployer
                 continue;
             }
             $path = $this->_basePath . '/releases/' . $release['name'];
-            $this->_exec('rm -rf ' . escapeshellarg($path));
+            $this->_sbin('rm-rf', [$path]);
         }
     }
 
@@ -1376,21 +1288,13 @@ class Modules_XveLaravelKit_Deployer
     private function _chownRelease($releasePath)
     {
         $user = $this->_getSystemUser();
-        // Recursively chown the release directory — it's a fresh clone so this is safe and necessary.
-        $this->_exec(sprintf('chown -R %s:%s %s',
-            escapeshellarg($user),
-            escapeshellarg('psaserv'),
-            escapeshellarg($releasePath)
-        ));
+        // Recursively chown the release directory; it's a fresh clone so this is safe and necessary.
+        $this->_sbin('chown-r', [$user, 'psaserv', $releasePath]);
         // Only chown the shared/ directory itself (non-recursive). The contents are
         // persistent across deploys and already have correct ownership, so running
         // chown -R on every deploy is unnecessarily slow on large upload/storage trees.
         $sharedPath = $this->_basePath . '/shared';
-        $this->_exec(sprintf('chown %s:%s %s',
-            escapeshellarg($user),
-            escapeshellarg('psaserv'),
-            escapeshellarg($sharedPath)
-        ));
+        $this->_sbin('chown', [$user, 'psaserv', $sharedPath]);
     }
 
     /**
@@ -1407,13 +1311,8 @@ class Modules_XveLaravelKit_Deployer
         $group = 'psaserv';
 
         // chown -h on the basepath itself fixes symlinks without following them,
-        // and also fixes regular files/dirs. Non-recursive — releases are chowned individually.
-        $this->_exec(sprintf(
-            'find %s -maxdepth 1 -exec chown -h %s:%s {} + 2>/dev/null || true',
-            escapeshellarg($this->_basePath),
-            escapeshellarg($user),
-            escapeshellarg($group)
-        ));
+        // and also fixes regular files/dirs. Non-recursive: releases are chowned individually.
+        $this->_sbin('fix-vhost-ownership', [$user, $group, $this->_basePath]);
     }
 
     private function _getReleaseStatusMap()
@@ -1496,7 +1395,7 @@ class Modules_XveLaravelKit_Deployer
         // 3. Last resort: newest installed PHP. This can pick a version the app does
         //    not support (e.g. a freshly installed 8.5), so make it visible in the log.
         try {
-            $dir = trim($this->_exec('ls -d /opt/plesk/php/*/bin 2>/dev/null | sort -V | tail -1'));
+            $dir = trim($this->_sbin('php-bindir-latest', []));
             if ($dir !== '') {
                 \pm_Log::warn('xve-laravel-kit: falling back to newest installed PHP (' . $dir
                     . '). Set an explicit PHP version in the deploy settings if this is wrong.');
@@ -1510,7 +1409,7 @@ class Modules_XveLaravelKit_Deployer
     private function _dirExists($path)
     {
         try {
-            $result = $this->_exec('test -d ' . escapeshellarg($path) . ' && echo "yes" || echo "no"');
+            $result = $this->_sbin('test-dir', [$path]);
             return trim($result) === 'yes';
         } catch (\Throwable $e) {
             return false;
@@ -1536,13 +1435,13 @@ class Modules_XveLaravelKit_Deployer
         return $parsed;
     }
 
-    private function _checkTool($name, $cmd)
+    private function _checkGitTool()
     {
         try {
-            $output = trim($this->_exec($cmd . ' 2>&1'));
-            return ['name' => $name, 'ok' => true, 'version' => $output, 'required' => false];
+            $output = trim($this->_sbin('git-version', []));
+            return ['name' => 'git', 'ok' => true, 'version' => $output, 'required' => false];
         } catch (\Throwable $e) {
-            return ['name' => $name, 'ok' => false, 'version' => 'Not found', 'required' => false];
+            return ['name' => 'git', 'ok' => false, 'version' => 'Not found', 'required' => false];
         }
     }
 
@@ -1553,8 +1452,11 @@ class Modules_XveLaravelKit_Deployer
             $name = $m[1];
         }
         try {
-            $fullCmd = sprintf('su -s /bin/bash %s -c %s 2>&1', escapeshellarg($user), escapeshellarg($cmd));
-            $output = trim($this->_exec($fullCmd));
+            $scriptPath = $this->_basePath . '/.xve-toolcheck-' . uniqid() . '.sh';
+            $this->_fileManager->filePutContents($scriptPath, "#!/bin/bash\n" . $cmd . "\n");
+            $this->_sbin('chmod', ['+x', $scriptPath]);
+            $output = trim($this->_sbin('run-script-as-user', [$user, $scriptPath]));
+            $this->_sbin('rm-f', [$scriptPath]);
             if (stripos($output, 'not found') !== false || stripos($output, 'No such file') !== false) {
                 return ['name' => $name, 'ok' => false, 'version' => 'Not found', 'required' => false];
             }
@@ -1564,9 +1466,9 @@ class Modules_XveLaravelKit_Deployer
         }
     }
 
-    private function _exec($cmd)
+    private function _sbin($subcommand, array $args = [])
     {
-        $result = pm_ApiCli::callSbin(self::SBIN_SCRIPT, [$cmd]);
+        $result = pm_ApiCli::callSbin(self::SBIN_SCRIPT, array_merge([$subcommand], $args));
         return isset($result['stdout']) ? $result['stdout'] : '';
     }
 
@@ -1580,7 +1482,7 @@ class Modules_XveLaravelKit_Deployer
     public function runDeploySteps($phase, $releasePath) { $this->_runDeploySteps($phase, $releasePath); }
     public function healthCheck() { $this->_healthCheck(); }
     public function cleanup() { $this->_cleanup(); }
-    public function removeRelease($releasePath) { $this->_exec('rm -rf ' . escapeshellarg($releasePath)); }
+    public function removeRelease($releasePath) { $this->_sbin('rm-rf', [$releasePath]); }
 
     public function parkFailedRelease($releasePath)
     {
@@ -1588,9 +1490,9 @@ class Modules_XveLaravelKit_Deployer
         $parkedPath = $basePath . '/releases/_last_failed_release';
 
         // Remove any previously parked failed release
-        $this->_exec('rm -rf ' . escapeshellarg($parkedPath));
+        $this->_sbin('rm-rf', [$parkedPath]);
         // Move the failed release to the parked location
-        $this->_exec('mv ' . escapeshellarg($releasePath) . ' ' . escapeshellarg($parkedPath));
+        $this->_sbin('mv', [$releasePath, $parkedPath]);
     }
     public function ensureArtisanSymlink() { $this->_ensureArtisanSymlink(); }
     public function ensureStorageLink($releasePath) { $this->_ensureStorageLink($releasePath); }

--- a/xve-laravel-kit/src/plib/library/Form/Settings.php
+++ b/xve-laravel-kit/src/plib/library/Form/Settings.php
@@ -22,8 +22,14 @@ class Modules_XveLaravelKit_Form_Settings extends pm_Form_Simple
             'required' => true,
             'validators' => [
                 ['NotEmpty', true],
+                ['Callback', false, [
+                    'callback' => ['Modules_XveLaravelKit_DeploySettings', 'validateRepoUrl'],
+                    'messages' => [
+                        Zend_Validate_Callback::INVALID_VALUE => 'Repository URL must be an SSH URL to an allowed GitHub org, e.g. git@github.com:your-org/your-repo.git',
+                    ],
+                ]],
             ],
-            'description' => 'SSH (git@github.com:user/repo.git) or HTTPS for public repos',
+            'description' => 'SSH URL to an allowed GitHub repo only, e.g. git@github.com:your-org/your-repo.git',
         ]);
 
         $this->addElement('text', 'branch', [
@@ -122,6 +128,13 @@ class Modules_XveLaravelKit_Form_Settings extends pm_Form_Simple
             'value' => $this->_settings->isTeamsNotifyEnabled() ? '1' : '0',
             'checked' => $this->_settings->isTeamsNotifyEnabled(),
             'description' => 'Send deploy status (success/failure) to the Teams webhook configured in the extension settings',
+        ]);
+
+        $this->addElement('checkbox', 'webhook_allow_force', [
+            'label' => 'Allow webhook force-deploy',
+            'value' => $this->_settings->isWebhookForceAllowed() ? '1' : '0',
+            'checked' => $this->_settings->isWebhookForceAllowed(),
+            'description' => 'Permit a webhook call with {"force": true} to cancel an in-progress deploy and start a new one. Leave off unless your CI needs to pre-empt running deploys.',
         ]);
 
         $this->addElement('text', 'keep_releases', [

--- a/xve-laravel-kit/src/plib/library/RateLimiter.php
+++ b/xve-laravel-kit/src/plib/library/RateLimiter.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Per-key sliding-window rate limiter backed by the extension var dir.
+ *
+ * Uses exclusive file locks (flock) around every read-modify-write cycle to
+ * remain safe under concurrent requests. On any IO failure the limiter fails
+ * open, so a storage problem can never block a legitimate deploy.
+ */
+class Modules_XveLaravelKit_RateLimiter
+{
+    /**
+     * Check whether the given key is within the allowed rate, and record the hit.
+     *
+     * @param  string $key            Arbitrary client identifier (e.g. an IP address).
+     * @param  int    $maxRequests    Maximum requests allowed within $windowSeconds.
+     * @param  int    $windowSeconds  Rolling window length in seconds.
+     * @return bool   true  = request is permitted (hit recorded).
+     *                false = limit exceeded (hit not recorded).
+     */
+    public static function allow($key, $maxRequests = 20, $windowSeconds = 60)
+    {
+        $dir = pm_Context::getVarDir() . 'webhook-ratelimit/';
+
+        // Create the storage directory on first use.
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0700, true);
+        }
+
+        // Key the counter file on a SHA-256 of the raw key so a raw IP never
+        // becomes part of the filesystem path and there are no path-traversal risks.
+        $file = $dir . hash('sha256', $key) . '.json';
+
+        $fh = @fopen($file, 'c+');
+        if ($fh === false) {
+            // Cannot open the file; fail open so storage issues don't break deploys.
+            return true;
+        }
+
+        if (!flock($fh, LOCK_EX)) {
+            fclose($fh);
+            return true;
+        }
+
+        try {
+            $now    = time();
+            $raw    = stream_get_contents($fh);
+            $data   = ($raw !== false && $raw !== '') ? json_decode($raw, true) : null;
+
+            // Initialise or reset when the window has expired.
+            if (!is_array($data) || ($now - $data['window_start']) >= $windowSeconds) {
+                $data = ['window_start' => $now, 'count' => 0];
+            }
+
+            if ($data['count'] >= $maxRequests) {
+                return false;
+            }
+
+            $data['count']++;
+
+            rewind($fh);
+            ftruncate($fh, 0);
+            fwrite($fh, json_encode($data));
+            fflush($fh);
+
+            return true;
+        } finally {
+            flock($fh, LOCK_UN);
+            fclose($fh);
+        }
+    }
+
+    /**
+     * Return how many seconds remain in the current window for the given key.
+     *
+     * Returns 0 when no window is active (window expired or file absent).
+     * Always fails open: returns 0 on any IO error.
+     *
+     * @param  string $key
+     * @param  int    $windowSeconds Must match the value passed to allow().
+     * @return int    Seconds until the window resets (>= 0).
+     */
+    public static function retryAfter($key, $windowSeconds = 60)
+    {
+        $dir  = pm_Context::getVarDir() . 'webhook-ratelimit/';
+        $file = $dir . hash('sha256', $key) . '.json';
+
+        $raw = @file_get_contents($file);
+        if ($raw === false || $raw === '') {
+            return 0;
+        }
+
+        $data = json_decode($raw, true);
+        if (!is_array($data) || !isset($data['window_start'])) {
+            return 0;
+        }
+
+        $elapsed   = time() - $data['window_start'];
+        $remaining = $windowSeconds - $elapsed;
+
+        return $remaining > 0 ? (int) $remaining : 0;
+    }
+}

--- a/xve-laravel-kit/src/plib/library/SshKey.php
+++ b/xve-laravel-kit/src/plib/library/SshKey.php
@@ -2,6 +2,29 @@
 
 class Modules_XveLaravelKit_SshKey
 {
+    // GitHub SSH host keys, verified against
+    // https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+    const GITHUB_KNOWN_HOSTS =
+        "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl\n" .
+        "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=\n" .
+        "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=\n";
+
+    public static function getKnownHostsPath(Modules_XveLaravelKit_DeploySettings $settings)
+    {
+        return $settings->getSshKeyDir() . '/known_hosts';
+    }
+
+    public static function ensureKnownHosts(Modules_XveLaravelKit_DeploySettings $settings)
+    {
+        self::ensure($settings); // guarantees the key dir exists
+        $path = self::getKnownHostsPath($settings);
+        $fm = new pm_ServerFileManager();
+        if (!$fm->fileExists($path) || trim($fm->fileGetContents($path)) === '') {
+            $fm->filePutContents($path, self::GITHUB_KNOWN_HOSTS);
+        }
+        return $path;
+    }
+
     public static function ensure(Modules_XveLaravelKit_DeploySettings $settings)
     {
         $keyDir = $settings->getSshKeyDir();
@@ -11,21 +34,19 @@ class Modules_XveLaravelKit_SshKey
             return;
         }
 
-        $cmd = sprintf(
-            'mkdir -p %s && ssh-keygen -t ed25519 -f %s -N "" -C %s 2>&1',
-            escapeshellarg($keyDir),
-            escapeshellarg($privateKey),
-            escapeshellarg('xve-deploy@' . $settings->getDomain()->getDisplayName())
-        );
-
-        pm_ApiCli::callSbin('xve-exec.sh', [$cmd]);
+        pm_ApiCli::callSbin('xve-exec.sh', [
+            'ssh-keygen',
+            $keyDir,
+            $privateKey,
+            'xve-deploy@' . $settings->getDomain()->getDisplayName(),
+        ]);
     }
 
     public static function remove(Modules_XveLaravelKit_DeploySettings $settings)
     {
         $keyDir = $settings->getSshKeyDir();
         if (is_dir($keyDir)) {
-            pm_ApiCli::callSbin('xve-exec.sh', ['rm -rf ' . escapeshellarg($keyDir)]);
+            pm_ApiCli::callSbin('xve-exec.sh', ['rm-rf', $keyDir]);
         }
     }
 

--- a/xve-laravel-kit/src/plib/library/TeamsNotifier.php
+++ b/xve-laravel-kit/src/plib/library/TeamsNotifier.php
@@ -81,19 +81,12 @@ class Modules_XveLaravelKit_TeamsNotifier
 
         pm_Log::info('Teams webhook: sending to ' . substr($url, 0, 60) . '...');
 
-        // Use shell curl via callSbin — guaranteed to work from Plesk task context
+        // Use shell curl via callSbin; guaranteed to work from Plesk task context
         // (PHP curl in sw-engine may lack CA certs or curl extension)
-        $cmd = sprintf(
-            'curl -sf -m 10 -H %s -d %s %s 2>&1',
-            escapeshellarg('Content-Type: application/json'),
-            escapeshellarg($json),
-            escapeshellarg($url)
-        );
-
         try {
-            $result = pm_ApiCli::callSbin('xve-exec.sh', [$cmd]);
+            $result = pm_ApiCli::callSbin('xve-exec.sh', ['curl-teams', $url, $json]);
             $output = isset($result['stdout']) ? trim($result['stdout']) : '';
-            pm_Log::info('Teams webhook: sent OK — ' . $output);
+            pm_Log::info('Teams webhook: sent OK - ' . $output);
         } catch (\Throwable $e) {
             pm_Log::warn('Teams webhook failed: ' . $e->getMessage());
         }

--- a/xve-laravel-kit/src/plib/views/scripts/domain/settings.phtml
+++ b/xve-laravel-kit/src/plib/views/scripts/domain/settings.phtml
@@ -33,20 +33,24 @@
 
 <?php if (!empty($this->webhookUrl)): ?>
 <div style="margin-bottom: 20px; padding: 15px; background: #f0f7ff; border: 1px solid #b3d4fc; border-radius: 4px;">
-    <h3 style="margin-top: 0;">Webhook URL</h3>
+    <h3 style="margin-top: 0;">Webhook</h3>
     <p style="margin-bottom: 8px;">
-        Call this URL with a <strong>POST</strong> request to trigger a deployment (e.g., from GitHub Actions).
+        Call this endpoint with a <strong>POST</strong> request to trigger a deployment (e.g., from GitHub Actions).
+        Pass the secret via the <code>Authorization: Bearer</code> header. The <code>?secret=</code> query form is no longer accepted.
     </p>
+    <p style="margin-bottom: 4px; font-size: 13px; color: #555;"><strong>Endpoint URL:</strong></p>
     <textarea readonly rows="2" style="width: 100%; font-family: monospace; font-size: 12px; background: #fff; border: 1px solid #ccc; padding: 8px;"
               onclick="this.select();"><?php echo $this->escape($this->webhookUrl); ?></textarea>
+    <p style="margin-top: 8px; margin-bottom: 4px; font-size: 13px; color: #555;">
+        <strong>Webhook secret</strong> (store this in your CI secrets, e.g. as <code>DEPLOY_WEBHOOK_SECRET</code>):
+    </p>
+    <textarea readonly rows="2" style="width: 100%; font-family: monospace; font-size: 12px; background: #fff; border: 1px solid #ccc; padding: 8px;"
+              onclick="this.select();"><?php echo $this->escape($this->webhookSecret); ?></textarea>
     <p style="margin-top: 8px; margin-bottom: 4px; font-size: 13px; color: #555;">
         <strong>GitHub Actions example:</strong>
     </p>
     <pre style="background: #fff; border: 1px solid #ccc; padding: 8px; font-size: 12px; overflow-x: auto; margin: 0;">- name: Trigger deploy
-  run: curl -sf -X POST "<?php echo $this->escape($this->webhookUrl); ?>"</pre>
-    <p style="margin-top: 8px; margin-bottom: 0; font-size: 12px; color: #888;">
-        Or use <code>Authorization: Bearer &lt;secret&gt;</code> header instead of the query parameter.
-    </p>
+  run: curl -sf -X POST -H "Authorization: Bearer ${{ secrets.DEPLOY_WEBHOOK_SECRET }}" "<?php echo $this->escape($this->webhookUrl); ?>"</pre>
 </div>
 <?php endif; ?>
 

--- a/xve-laravel-kit/src/plib/views/scripts/index/settings.phtml
+++ b/xve-laravel-kit/src/plib/views/scripts/index/settings.phtml
@@ -32,3 +32,27 @@
         </div>
     </form>
 </div>
+
+<div style="padding: 20px; background: #f5f5f5; border: 1px solid #ddd; border-radius: 4px; max-width: 700px; margin-top: 20px;">
+    <h3 style="margin-top: 0;">Allowed Git Repositories</h3>
+    <p style="margin-bottom: 16px; font-size: 13px; color: #555;">
+        Deploys are restricted to SSH repositories on <code>github.com</code> owned by one of the
+        organizations below. List one GitHub org/owner per line. <strong>Until at least one org is
+        added, every repository is rejected</strong> and no deploy can run.
+    </p>
+
+    <form method="post" action="<?php echo Modules_XveLaravelKit_Url::action('index/settings'); ?>">
+        <div style="margin-bottom: 12px;">
+            <label style="display: block; font-weight: bold; margin-bottom: 4px; font-size: 13px;">Allowed GitHub organizations</label>
+            <textarea name="allowed_repo_owners" rows="4" placeholder="my-org&#10;another-org"
+                      style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 3px; font-size: 13px; font-family: monospace;"><?php echo $this->escape($this->allowedRepoOwners); ?></textarea>
+            <p style="margin: 4px 0 0; font-size: 12px; color: #888;">
+                One per line. Only <code>git@github.com:&lt;org&gt;/&lt;repo&gt;.git</code> URLs whose org appears here are accepted.
+            </p>
+        </div>
+
+        <div style="display: flex; gap: 8px; align-items: center;">
+            <button type="submit" class="btn btn-primary">Save</button>
+        </div>
+    </form>
+</div>

--- a/xve-laravel-kit/src/sbin/xve-exec.sh
+++ b/xve-laravel-kit/src/sbin/xve-exec.sh
@@ -1,2 +1,100 @@
 #!/bin/bash
-eval "$1"
+#
+# xve-exec.sh — privileged subcommand dispatcher for XVE Laravel Kit.
+#
+# Runs as root via Plesk's pm_ApiCli::callSbin. Replaces the previous
+# `eval "$1"` wrapper: there is NO eval and NO shell interpretation of
+# caller-supplied data. Each subcommand runs a FIXED command with the
+# caller's arguments passed as separate, quoted positional parameters.
+#
+# Usage: xve-exec.sh <subcommand> [args...]
+#
+set -euo pipefail
+
+# Build a pinned GIT_SSH_COMMAND. $1 = private key path, $2 = known_hosts path.
+git_ssh_cmd() {
+    printf 'ssh -i %q -o UserKnownHostsFile=%q -o StrictHostKeyChecking=yes -o IdentitiesOnly=yes -o PasswordAuthentication=no' "$1" "$2"
+}
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+    mkdir-p)            mkdir -p -- "$1" ;;
+    rm-f)               rm -f -- "$1" ;;
+    rm-rf)
+        [ -n "${1:-}" ] || { echo "rm-rf: empty path" >&2; exit 64; }
+        [ "$1" != "/" ] || { echo "rm-rf: refusing /" >&2; exit 64; }
+        rm -rf -- "$1" ;;
+    ln-sfn)             ln -sfn -- "$1" "$2" ;;
+    mv)                 mv -- "$1" "$2" ;;
+    mv-tf)              mv -Tf -- "$1" "$2" ;;
+    cp)                 cp -- "$1" "$2" ;;
+    chmod)              chmod "$1" -- "$2" ;;
+    chown)              chown "$1:$2" -- "$3" ;;
+    chown-h)            chown -h "$1:$2" -- "$3" ;;
+    chown-r)            chown -R "$1:$2" -- "$3" ;;
+    fix-shared-perms)
+        find "$1" -type d -exec chmod 775 {} +
+        find "$1" -type f -exec chmod 664 {} + ;;
+    truncate0)          truncate -s 0 -- "$1" ;;
+    tail-n)             tail -n "$1" -- "$2" 2>/dev/null ;;
+    ls-1r)              ls -1r -- "$1" 2>/dev/null ;;
+    test-dir)           if [ -d "$1" ]; then echo yes; else echo no; fi ;;
+    test-dir-writable)  if [ -d "$1" ] && [ -w "$1" ]; then echo yes; else echo no; fi ;;
+    tar-czf-shared)     tar -czf "$1" -C "$2" shared ;;
+
+    ssh-keygen)
+        mkdir -p -- "$1"
+        ssh-keygen -t ed25519 -f "$2" -N '' -C "$3" 2>&1 ;;
+
+    git-version)        git --version ;;
+    git-ls-remote)
+        GIT_SSH_COMMAND="$(git_ssh_cmd "$1" "$2")" git ls-remote --heads "$3" 2>&1 ;;
+    git-archive-file)
+        GIT_SSH_COMMAND="$(git_ssh_cmd "$1" "$2")" git archive --remote="$3" "$4" "$5" 2>/dev/null | tar -xO "$5" 2>/dev/null ;;
+    git-clone-file)
+        q=""; [ "$3" = "1" ] && q="--quiet"
+        GIT_SSH_COMMAND="$(git_ssh_cmd "$1" "$2")" git clone --depth 1 $q --no-checkout --branch "$4" "$5" "$6" 2>&1
+        git -C "$6" checkout HEAD -- "$7" 2>&1 ;;
+    git-clone)
+        q=""; [ "$3" = "1" ] && q="--quiet"
+        GIT_SSH_COMMAND="$(git_ssh_cmd "$1" "$2")" git clone --depth 1 $q --branch "$4" "$5" "$6" 2>&1 ;;
+    git-rev-parse)      git -C "$1" rev-parse HEAD 2>/dev/null ;;
+    git-log)
+        case "$2" in %s|%an) ;; *) echo "git-log: bad format" >&2; exit 64 ;; esac
+        git -C "$1" log -1 --pretty="$2" 2>/dev/null ;;
+
+    run-script-as-user)
+        # $1 = user, $2 = script path. Chowns to the user then runs it.
+        chown "$1" -- "$2" 2>/dev/null || true
+        su -s /bin/bash "$1" -c 'bash -- "$1"' xlk "$2" 2>&1 ;;
+
+    plesk-site-wwwroot)
+        plesk bin site --update "$1" -www-root "$2" ;;
+    plesk-subscription-create)
+        plesk bin subscription --create "$1" -owner admin -login "$2" -passwd "$3" -ip "$4" -hosting true 2>&1 ;;
+
+    curl-health)
+        curl -sfL --max-time "$1" -o /dev/null -w '%{http_code}' "$2" 2>&1 ;;
+    curl-teams)
+        curl -sf -m 10 -H 'Content-Type: application/json' -d "$2" "$1" 2>&1 ;;
+
+    php-version)
+        # $1 = absolute path to a php binary. Reads its version string.
+        "$1" -r 'echo PHP_VERSION;' 2>/dev/null ;;
+    php-bindir-latest)
+        # Newest installed Plesk PHP bin dir. Fixed glob, no caller input.
+        ls -d /opt/plesk/php/*/bin 2>/dev/null | sort -V | tail -1 || true ;;
+    fix-vhost-ownership)
+        # $1 user, $2 group, $3 basepath. chown -h top-level entries (incl. symlinks).
+        find "$3" -maxdepth 1 -exec chown -h "$1:$2" {} + 2>/dev/null || true ;;
+    detect-db)
+        # $1 = numeric Plesk domain id. SQL is fixed here; only the id crosses the boundary.
+        case "$1" in ''|*[!0-9]*) echo "detect-db: id must be numeric" >&2; exit 64 ;; esac
+        plesk db "SELECT db.name, du.login FROM data_bases db LEFT JOIN db_users du ON du.db_id = db.id WHERE db.dom_id = $1 LIMIT 1" ;;
+
+    *)
+        echo "xve-exec: unknown subcommand: $cmd" >&2
+        exit 64 ;;
+esac

--- a/xve-laravel-kit/tests/Unit/RepoUrlValidationTest.php
+++ b/xve-laravel-kit/tests/Unit/RepoUrlValidationTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Modules_XveLaravelKit_DeploySettings::validateRepoUrl().
+ *
+ * Only scp-style SSH URLs to an admin-configured GitHub org on github.com are
+ * accepted. The allowed orgs are an extension-level setting; with none set the
+ * validator fails closed. HTTPS, other hosts, other owners, traversal, and
+ * malformed input are all rejected.
+ */
+class RepoUrlValidationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Configure a single allowed org for the duration of each test.
+        Modules_XveLaravelKit_DeploySettings::setAllowedRepoOwners('allowed-org');
+    }
+
+    // ── Valid URLs that must be accepted ─────────────────────────────────────
+
+    public function testValidUrlWithDotGit(): void
+    {
+        $this->assertTrue(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('git@github.com:allowed-org/repo.git'),
+            'Standard scp SSH URL with .git suffix must be accepted'
+        );
+    }
+
+    public function testValidUrlWithoutDotGit(): void
+    {
+        $this->assertTrue(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('git@github.com:allowed-org/my-project'),
+            'scp SSH URL without .git suffix must be accepted'
+        );
+    }
+
+    public function testValidUrlWithHyphensAndDots(): void
+    {
+        $this->assertTrue(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('git@github.com:allowed-org/my.repo-name_v2.git'),
+            'Repo names with hyphens, dots, and underscores must be accepted'
+        );
+    }
+
+    public function testSecondConfiguredOrgIsAccepted(): void
+    {
+        Modules_XveLaravelKit_DeploySettings::setAllowedRepoOwners("allowed-org\nsecond-org");
+        $this->assertTrue(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('git@github.com:second-org/repo.git'),
+            'Any org in the configured allowlist must be accepted'
+        );
+    }
+
+    // ── Invalid: no allowlist configured (fail closed) ───────────────────────
+
+    public function testRejectedWhenNoOwnerConfigured(): void
+    {
+        Modules_XveLaravelKit_DeploySettings::setAllowedRepoOwners('');
+        $this->assertFalse(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('git@github.com:allowed-org/repo.git'),
+            'A well-formed URL must be rejected when no org is configured'
+        );
+    }
+
+    // ── Invalid: wrong protocol ───────────────────────────────────────────────
+
+    public function testHttpsUrlIsRejected(): void
+    {
+        $this->assertFalse(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('https://github.com/allowed-org/repo.git'),
+            'HTTPS URL must be rejected'
+        );
+    }
+
+    public function testSshProtocolUrlIsRejected(): void
+    {
+        $this->assertFalse(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('ssh://git@github.com/allowed-org/repo.git'),
+            'ssh:// protocol URL must be rejected (only scp-style git@ is accepted)'
+        );
+    }
+
+    // ── Invalid: wrong owner ──────────────────────────────────────────────────
+
+    public function testOtherOwnerIsRejected(): void
+    {
+        $this->assertFalse(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('git@github.com:evilcorp/repo.git'),
+            'URL with a non-allowlisted owner must be rejected'
+        );
+    }
+
+    // ── Invalid: wrong host ───────────────────────────────────────────────────
+
+    public function testOtherHostIsRejected(): void
+    {
+        $this->assertFalse(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('git@gitlab.com:allowed-org/repo.git'),
+            'URL pointing to gitlab.com must be rejected'
+        );
+    }
+
+    // ── Invalid: empty / whitespace ───────────────────────────────────────────
+
+    public function testEmptyStringIsRejected(): void
+    {
+        $this->assertFalse(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl(''),
+            'Empty string must be rejected'
+        );
+    }
+
+    public function testWhitespaceOnlyIsRejected(): void
+    {
+        $this->assertFalse(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('   '),
+            'Whitespace-only string must be rejected'
+        );
+    }
+
+    // ── Invalid: null ─────────────────────────────────────────────────────────
+
+    public function testNullIsRejected(): void
+    {
+        $this->assertFalse(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl(null),
+            'null must be rejected'
+        );
+    }
+
+    // ── Invalid: null byte injection ──────────────────────────────────────────
+
+    public function testNullByteIsRejected(): void
+    {
+        $this->assertFalse(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl("git@github.com:allowed-org/repo\0.git"),
+            'URL containing a null byte must be rejected'
+        );
+    }
+
+    // ── Invalid: path traversal ───────────────────────────────────────────────
+
+    public function testPathTraversalInRepoNameIsRejected(): void
+    {
+        $this->assertFalse(
+            Modules_XveLaravelKit_DeploySettings::validateRepoUrl('git@github.com:allowed-org/../etc/passwd'),
+            'Path traversal attempt in URL must be rejected'
+        );
+    }
+}


### PR DESCRIPTION
Security review follow-up. **Breaking:** the webhook no longer accepts the `?secret=` query parameter; callers must send `Authorization: Bearer <secret>`.

## Changes

- **Webhook auth is header-only.** Removed the `?secret=` query path (leaked tokens in access/proxy logs and `Referer`); secret read only from `Authorization: Bearer`. The Settings tab shows the token separately for CI secrets.
- **Webhook rate limiting** — 20 req/60s per client IP (`REMOTE_ADDR`), HTTP 429 + `Retry-After`; also throttles secret-guessing.
- **Per-domain force gate** — webhook `{"force": true}` is ignored unless *Allow webhook force-deploy* is enabled for that domain.
- **Repo URL allowlist** — only `git@github.com:<allowed-org>/...` SSH URLs are accepted, enforced in the settings form and again at deploy time. Fails closed when unconfigured. Allowed orgs are an **admin-level extension setting**, not hard-coded in this public source.
- **SSH host-key pinning** — git ops pin GitHub's host keys via a per-domain `known_hosts` with `StrictHostKeyChecking=yes`, replacing `accept-new`.
- **No more root `eval`** — `sbin/xve-exec.sh` is now an allowlisted argv subcommand dispatcher; every privileged call site passes argv, no shell interpretation of caller data.

## Verification

- `php -l` clean on all changed files; `bash -n` clean on the dispatcher.
- PHPUnit: **61 tests, 65 assertions, all passing** (added repo-URL allowlist tests incl. fail-closed).
- `build.sh` produces `xve-laravel-kit-2.1.0.zip`; no org literal in the artifact.

## Follow-up

- #17 — dev container (`init-sbin.sh`) still installs the legacy `eval` wrapper; sync it to the shipped dispatcher.

## Rollout note

The repo allowlist **fails closed**: an admin must enter the allowed GitHub org(s) under Extension Settings before any deploy will run (including existing prod domains).