### PR TITLE
fix(settings): merge extension settings into a single form (v2.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.1
+
+- Fix Extension Settings clobbering: the page had two separate forms posting to the same action, so saving Teams notifications wiped the repo allowlist (and vice versa). Both sections are now a single form, so all fields save together. An emptied allowlist fails closed and blocks deploys, so re-check both fields after upgrading
+
 ## v2.1.0
 
 Security hardening (OPS-25 review). **Breaking:** the webhook no longer accepts the `?secret=` query parameter; callers must send `Authorization: Bearer <secret>`.

--- a/xve-laravel-kit/src/meta.xml
+++ b/xve-laravel-kit/src/meta.xml
@@ -4,7 +4,7 @@
     <name>XVE Laravel Kit</name>
     <description>Atomic deployments with rollback, Laravel management tools, .env editor, artisan console, and log viewer. Built for zero-downtime deploys from Git repositories.</description>
     <category>developer</category>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <release>1</release>
     <vendor>XVE BV</vendor>
     <url>https://xve.be</url>

--- a/xve-laravel-kit/src/plib/views/scripts/index/settings.phtml
+++ b/xve-laravel-kit/src/plib/views/scripts/index/settings.phtml
@@ -9,15 +9,15 @@
     </div>
 </div>
 
-<div style="padding: 20px; background: #f5f5f5; border: 1px solid #ddd; border-radius: 4px; max-width: 700px;">
-    <h3 style="margin-top: 0;">Microsoft Teams Notifications</h3>
-    <p style="margin-bottom: 16px; font-size: 13px; color: #555;">
-        Configure a Teams Incoming Webhook URL to receive deploy notifications.
-        Enable notifications per domain in each domain's settings.
-    </p>
+<form method="post" action="<?php echo Modules_XveLaravelKit_Url::action('index/settings'); ?>">
+    <div style="padding: 20px; background: #f5f5f5; border: 1px solid #ddd; border-radius: 4px; max-width: 700px;">
+        <h3 style="margin-top: 0;">Microsoft Teams Notifications</h3>
+        <p style="margin-bottom: 16px; font-size: 13px; color: #555;">
+            Configure a Teams Incoming Webhook URL to receive deploy notifications.
+            Enable notifications per domain in each domain's settings.
+        </p>
 
-    <form method="post" action="<?php echo Modules_XveLaravelKit_Url::action('index/settings'); ?>">
-        <div style="margin-bottom: 12px;">
+        <div>
             <label style="display: block; font-weight: bold; margin-bottom: 4px; font-size: 13px;">Webhook URL</label>
             <input type="url" name="teams_webhook_url" placeholder="https://outlook.office.com/webhook/..."
                    value="<?php echo $this->escape($this->teamsWebhookUrl); ?>"
@@ -26,23 +26,17 @@
                 Create an Incoming Webhook connector in your Teams channel and paste the URL here.
             </p>
         </div>
+    </div>
 
-        <div style="display: flex; gap: 8px; align-items: center;">
-            <button type="submit" class="btn btn-primary">Save</button>
-        </div>
-    </form>
-</div>
+    <div style="padding: 20px; background: #f5f5f5; border: 1px solid #ddd; border-radius: 4px; max-width: 700px; margin-top: 20px;">
+        <h3 style="margin-top: 0;">Allowed Git Repositories</h3>
+        <p style="margin-bottom: 16px; font-size: 13px; color: #555;">
+            Deploys are restricted to SSH repositories on <code>github.com</code> owned by one of the
+            organizations below. List one GitHub org/owner per line. <strong>Until at least one org is
+            added, every repository is rejected</strong> and no deploy can run.
+        </p>
 
-<div style="padding: 20px; background: #f5f5f5; border: 1px solid #ddd; border-radius: 4px; max-width: 700px; margin-top: 20px;">
-    <h3 style="margin-top: 0;">Allowed Git Repositories</h3>
-    <p style="margin-bottom: 16px; font-size: 13px; color: #555;">
-        Deploys are restricted to SSH repositories on <code>github.com</code> owned by one of the
-        organizations below. List one GitHub org/owner per line. <strong>Until at least one org is
-        added, every repository is rejected</strong> and no deploy can run.
-    </p>
-
-    <form method="post" action="<?php echo Modules_XveLaravelKit_Url::action('index/settings'); ?>">
-        <div style="margin-bottom: 12px;">
+        <div>
             <label style="display: block; font-weight: bold; margin-bottom: 4px; font-size: 13px;">Allowed GitHub organizations</label>
             <textarea name="allowed_repo_owners" rows="4" placeholder="my-org&#10;another-org"
                       style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 3px; font-size: 13px; font-family: monospace;"><?php echo $this->escape($this->allowedRepoOwners); ?></textarea>
@@ -50,9 +44,9 @@
                 One per line. Only <code>git@github.com:&lt;org&gt;/&lt;repo&gt;.git</code> URLs whose org appears here are accepted.
             </p>
         </div>
+    </div>
 
-        <div style="display: flex; gap: 8px; align-items: center;">
-            <button type="submit" class="btn btn-primary">Save</button>
-        </div>
-    </form>
-</div>
+    <div style="display: flex; gap: 8px; align-items: center; max-width: 700px; margin-top: 16px;">
+        <button type="submit" class="btn btn-primary">Save Settings</button>
+    </div>
+</form>


### PR DESCRIPTION
## Bug

The Extension Settings page rendered **two separate `<form>`s** (Teams notifications, Allowed Git Repositories) both posting to `index/settings`, but `settingsAction()` reads *both* fields on every save. Submitting one form omits the other field, so `getParam(..., '')` overwrites the stored value with empty:

- Saving **Teams settings** wiped the **repo allowlist**, and vice versa.
- Because the allowlist **fails closed**, an emptied allowlist silently blocks **all** deploys.

Reported from the live v2.1.0 panel.

## Fix

Combine both sections into a **single `<form>`** with one **Save Settings** button, so both fields always submit together. No controller change — `settingsAction()` already persists both fields and now always receives both.

## Verification

- `php -l` clean on the view.
- Markup check: exactly one `<form>`/`</form>`, one submit button, both fields present.
- Existing PHPUnit suite unaffected (no PHP logic changed).