### PR TITLE
feat(teams): Adaptive Card deploy notifications (v2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.0
+
+- Teams deploy notifications are now **Adaptive Cards** (icon + title, fact set, and Open site / View commit actions) sent as the Power Automate Workflows envelope, matching the nassau deployer. **Action required:** the Teams webhook must be a Teams *Workflow* URL ("Post to a channel when a webhook request is received") — legacy Office 365 connector URLs no longer render these cards. Reconfigure the webhook under Extension Settings after upgrading
+
 ## v2.1.1
 
 - Fix Extension Settings clobbering: the page had two separate forms posting to the same action, so saving Teams notifications wiped the repo allowlist (and vice versa). Both sections are now a single form, so all fields save together. An emptied allowlist fails closed and blocks deploys, so re-check both fields after upgrading

--- a/xve-laravel-kit/src/meta.xml
+++ b/xve-laravel-kit/src/meta.xml
@@ -4,7 +4,7 @@
     <name>XVE Laravel Kit</name>
     <description>Atomic deployments with rollback, Laravel management tools, .env editor, artisan console, and log viewer. Built for zero-downtime deploys from Git repositories.</description>
     <category>developer</category>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
     <release>1</release>
     <vendor>XVE BV</vendor>
     <url>https://xve.be</url>

--- a/xve-laravel-kit/src/plib/library/Task/Deploy.php
+++ b/xve-laravel-kit/src/plib/library/Task/Deploy.php
@@ -356,7 +356,8 @@ class Modules_XveLaravelKit_Task_Deploy extends pm_LongTask_Task
                 $status,
                 $settings->getBranch(),
                 $commitInfo,
-                $error
+                $error,
+                $settings->getRepoWebUrl()
             );
         } catch (\Throwable $e) {
             pm_Log::warn('Teams notification failed: ' . $e->getMessage());

--- a/xve-laravel-kit/src/plib/library/TeamsNotifier.php
+++ b/xve-laravel-kit/src/plib/library/TeamsNotifier.php
@@ -15,16 +15,20 @@ class Modules_XveLaravelKit_TeamsNotifier
     }
 
     /**
-     * Send a deploy notification to Teams.
+     * Send a deploy notification to Teams as an Adaptive Card.
+     *
+     * Posts the Power Automate Workflows envelope ({type: message, attachments:[adaptive card]}),
+     * so the configured webhook must be a Teams "Workflow" URL, not a legacy O365 connector.
      *
      * @param string $domainName
      * @param string $release
-     * @param string $status  'success' or 'failed'
+     * @param string $status      'success' or 'failed'
      * @param string $branch
      * @param array|null $commitInfo  ['hash' => ..., 'message' => ..., 'author' => ...]
-     * @param string $error   Error message (for failed deploys)
+     * @param string $error       Error message (for failed deploys)
+     * @param string $repoWebUrl  Repo web URL, used for the "View commit" action (optional)
      */
-    public static function notifyDeploy($domainName, $release, $status, $branch = '', $commitInfo = null, $error = '')
+    public static function notifyDeploy($domainName, $release, $status, $branch = '', $commitInfo = null, $error = '', $repoWebUrl = '')
     {
         $webhookUrl = self::getWebhookUrl();
         if (empty($webhookUrl)) {
@@ -32,43 +36,99 @@ class Modules_XveLaravelKit_TeamsNotifier
         }
 
         $isSuccess = ($status === 'success');
-        $themeColor = $isSuccess ? '2e7d32' : 'e74c3c';
-        $statusText = $isSuccess ? 'Deployed successfully' : 'Deploy failed';
-        $statusIcon = $isSuccess ? "\xe2\x9c\x85" : "\xe2\x9d\x8c";
+        $title    = $isSuccess ? 'Deploy succeeded' : 'Deploy failed';
+        $icon     = $isSuccess ? "\xe2\x9c\x85" : "\xe2\x9d\x8c"; // ✅ / ❌
+        $color    = $isSuccess ? 'Good' : 'Attention';
+        $subtitle = $isSuccess ? $domainName . ' is live' : $domainName . ' deploy failed';
 
         $facts = [
-            ['name' => 'Domain', 'value' => $domainName],
-            ['name' => 'Release', 'value' => $release],
-            ['name' => 'Status', 'value' => $statusIcon . ' ' . $statusText],
+            ['title' => 'Domain', 'value' => $domainName],
+            ['title' => 'Release', 'value' => $release],
         ];
-
         if (!empty($branch)) {
-            $facts[] = ['name' => 'Branch', 'value' => $branch];
+            $facts[] = ['title' => 'Branch', 'value' => $branch];
         }
-
         if ($commitInfo && !empty($commitInfo['hash'])) {
             $hash = substr($commitInfo['hash'], 0, 7);
             $msg = $commitInfo['message'] ?? '';
-            $facts[] = ['name' => 'Commit', 'value' => $hash . ($msg ? ' — ' . $msg : '')];
+            $facts[] = ['title' => 'Commit', 'value' => '`' . $hash . '`' . ($msg ? ' ' . $msg : '')];
             if (!empty($commitInfo['author'])) {
-                $facts[] = ['name' => 'Author', 'value' => $commitInfo['author']];
+                $facts[] = ['title' => 'Author', 'value' => $commitInfo['author']];
             }
         }
-
+        $facts[] = ['title' => 'Time', 'value' => date('Y-m-d H:i T')];
         if (!$isSuccess && !empty($error)) {
-            $facts[] = ['name' => 'Error', 'value' => $error];
+            $facts[] = ['title' => 'Error', 'value' => $error];
+        }
+
+        $actions = [];
+        if (!empty($domainName)) {
+            $actions[] = ['type' => 'Action.OpenUrl', 'title' => 'Open site', 'url' => 'https://' . $domainName];
+        }
+        if (!empty($repoWebUrl) && $commitInfo && !empty($commitInfo['hash'])) {
+            $actions[] = ['type' => 'Action.OpenUrl', 'title' => 'View commit', 'url' => rtrim($repoWebUrl, '/') . '/commit/' . $commitInfo['hash']];
+        }
+
+        $body = [
+            [
+                'type' => 'ColumnSet',
+                'columns' => [
+                    [
+                        'type' => 'Column',
+                        'width' => 'auto',
+                        'verticalContentAlignment' => 'Center',
+                        'items' => [[
+                            'type' => 'TextBlock',
+                            'text' => $icon,
+                            'size' => 'ExtraLarge',
+                            'spacing' => 'None',
+                        ]],
+                    ],
+                    [
+                        'type' => 'Column',
+                        'width' => 'stretch',
+                        'items' => [
+                            [
+                                'type' => 'TextBlock',
+                                'text' => $title,
+                                'size' => 'Large',
+                                'weight' => 'Bolder',
+                                'color' => $color,
+                                'spacing' => 'None',
+                            ],
+                            [
+                                'type' => 'TextBlock',
+                                'text' => $subtitle,
+                                'isSubtle' => true,
+                                'spacing' => 'None',
+                                'wrap' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'FactSet',
+                'separator' => true,
+                'facts' => $facts,
+            ],
+        ];
+        if (!empty($actions)) {
+            $body[] = ['type' => 'ActionSet', 'actions' => $actions];
         }
 
         $card = [
-            '@type' => 'MessageCard',
-            '@context' => 'http://schema.org/extensions',
-            'themeColor' => $themeColor,
-            'summary' => $domainName . ' — ' . $statusText,
-            'sections' => [[
-                'activityTitle' => $domainName,
-                'activitySubtitle' => $statusText,
-                'facts' => $facts,
-                'markdown' => true,
+            'type' => 'message',
+            'attachments' => [[
+                'contentType' => 'application/vnd.microsoft.card.adaptive',
+                'contentUrl' => null,
+                'content' => [
+                    '$schema' => 'http://adaptivecards.io/schemas/adaptive-card.json',
+                    'type' => 'AdaptiveCard',
+                    'version' => '1.4',
+                    'msteams' => ['width' => 'Full'],
+                    'body' => $body,
+                ],
             ]],
         ];
 

--- a/xve-laravel-kit/src/plib/views/scripts/index/settings.phtml
+++ b/xve-laravel-kit/src/plib/views/scripts/index/settings.phtml
@@ -13,17 +13,18 @@
     <div style="padding: 20px; background: #f5f5f5; border: 1px solid #ddd; border-radius: 4px; max-width: 700px;">
         <h3 style="margin-top: 0;">Microsoft Teams Notifications</h3>
         <p style="margin-bottom: 16px; font-size: 13px; color: #555;">
-            Configure a Teams Incoming Webhook URL to receive deploy notifications.
+            Send deploy notifications to a Microsoft Teams channel via a Power Automate
+            <strong>Workflow</strong> ("Post to a channel when a webhook request is received").
             Enable notifications per domain in each domain's settings.
         </p>
 
         <div>
             <label style="display: block; font-weight: bold; margin-bottom: 4px; font-size: 13px;">Webhook URL</label>
-            <input type="url" name="teams_webhook_url" placeholder="https://outlook.office.com/webhook/..."
+            <input type="url" name="teams_webhook_url" placeholder="https://prod-00.westeurope.logic.azure.com/workflows/..."
                    value="<?php echo $this->escape($this->teamsWebhookUrl); ?>"
                    style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 3px; font-size: 13px; font-family: monospace;" />
             <p style="margin: 4px 0 0; font-size: 12px; color: #888;">
-                Create an Incoming Webhook connector in your Teams channel and paste the URL here.
+                Create a Teams <strong>Workflow</strong> from the "Post to a channel when a webhook request is received" template and paste its URL here. Legacy Office&nbsp;365 connector URLs are no longer supported.
             </p>
         </div>
     </div>


### PR DESCRIPTION
Ports the **nassau `deploy.php`** Teams card to this module so deploy success/failure notifications are **Adaptive Cards** instead of the legacy MessageCard.

## Changes

- `TeamsNotifier::notifyDeploy()` now builds the Power Automate **Workflows envelope** (`{type: message, attachments: [{contentType: application/vnd.microsoft.card.adaptive, content: AdaptiveCard v1.4}]}`):
  - Header: ✅/❌ icon + **Deploy succeeded/failed** title (Good/Attention colour) and a `<domain> is live` / `deploy failed` subtitle.
  - **FactSet**: Domain, Release, Branch, Commit (`` `hash` message ``), Author, Time, and Error (failures).
  - **Actions**: *Open site* (`https://<domain>`) and *View commit* (`<repoWebUrl>/commit/<hash>`).
- `Task/Deploy.php` threads `$settings->getRepoWebUrl()` through for the commit link (new optional 7th arg, backward-compatible).
- Extension Settings guidance + placeholder now point at a Teams **Workflow** webhook.

Mirrors nassau's structure (ColumnSet + FactSet + ActionSet, `msteams.width=Full`).

## Verification

- `php -l` clean on all changed files.
- Throwaway harness (stubbed SDK) builds **valid JSON** for both success and failure; envelope/contentType/version and both actions confirmed.
- Existing PHPUnit suite unaffected.

## ⚠️ Migration (ops)

The module now sends the Workflows envelope, which a legacy **Office 365 connector** URL will not render. After deploying v2.2.0, reconfigure the Teams webhook (Extension Settings) as a Teams **Workflow** ("Post to a channel when a webhook request is received"). nassau already uses a Workflow webhook.

## Out of scope

`.github/workflows/build-release.yml` still posts a MessageCard for *extension release* announcements (a different webhook/secret). Can convert separately if wanted.