### PR TITLE
fix(deploy): fail fast when node_build step has no build script in pa…

### DIFF
--- a/xve-laravel-kit/src/plib/library/Deployer.php
+++ b/xve-laravel-kit/src/plib/library/Deployer.php
@@ -1275,6 +1275,16 @@ class Modules_XveLaravelKit_Deployer
                     break;
                 case 'node_build':
                     $pm = $this->_detectNodePackageManager($releasePath);
+                    $packageJsonPath = $releasePath . '/package.json';
+                    if ($this->_fileManager->fileExists($packageJsonPath)) {
+                        $pkgJson = json_decode($this->_fileManager->fileGetContents($packageJsonPath), true);
+                        if (empty($pkgJson['scripts']['build'])) {
+                            throw new \RuntimeException(
+                                'The "Build frontend assets" deploy step is enabled but package.json has no "build" script. ' .
+                                'Either add a build script to package.json or disable this step in the deploy settings.'
+                            );
+                        }
+                    }
                     $cmd = $pm . ' run build';
                     if ($q && $pm === 'npm') $cmd .= ' --silent';
                     $commands[] = $cmd . ' 2>&1';

--- a/xve-laravel-kit/src/plib/library/Form/Settings.php
+++ b/xve-laravel-kit/src/plib/library/Form/Settings.php
@@ -129,7 +129,7 @@ class Modules_XveLaravelKit_Form_Settings extends pm_Form_Simple
             'value' => $this->_settings->getKeepReleases(),
             'required' => true,
             'validators' => [
-                ['Int'],
+                ['Int', false],
                 ['Between', false, ['min' => 1, 'max' => 20]],
             ],
             'description' => 'Number of previous releases to keep for rollback (1-20)',
@@ -147,7 +147,7 @@ class Modules_XveLaravelKit_Form_Settings extends pm_Form_Simple
             'value' => $this->_settings->getHealthCheckTimeout(),
             'required' => false,
             'validators' => [
-                ['Int'],
+                ['Int', false],
                 ['Between', false, ['min' => 5, 'max' => 300]],
             ],
         ]);


### PR DESCRIPTION
…ckage.json

Previously the error was buried after 200+ lines of npm deprecation warnings. Now throws a clear, actionable message pointing to the deploy settings.