### PR TITLE
fix(settings): fix Int validator single-element array causing callbac…

### DIFF
--- a/xve-laravel-kit/src/plib/library/Form/Settings.php
+++ b/xve-laravel-kit/src/plib/library/Form/Settings.php
@@ -129,7 +129,7 @@ class Modules_XveLaravelKit_Form_Settings extends pm_Form_Simple
             'value' => $this->_settings->getKeepReleases(),
             'required' => true,
             'validators' => [
-                ['Int'],
+                ['Int', false],
                 ['Between', false, ['min' => 1, 'max' => 20]],
             ],
             'description' => 'Number of previous releases to keep for rollback (1-20)',
@@ -147,7 +147,7 @@ class Modules_XveLaravelKit_Form_Settings extends pm_Form_Simple
             'value' => $this->_settings->getHealthCheckTimeout(),
             'required' => false,
             'validators' => [
-                ['Int'],
+                ['Int', false],
                 ['Between', false, ['min' => 5, 'max' => 300]],
             ],
         ]);


### PR DESCRIPTION
…k TypeError

Zend Framework interprets a single-element array validator as a PHP callback [class, method], which requires exactly two members. Added the missing breakChain=false second argument to both Int validators.