### PR TITLE
fix(settings): repo-URL allowlist via controller, not Zend Callback validator (v2.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.1
+
+- Fix `TypeError: array callback must have exactly two members` (Zend Callback.php) when opening/saving a domain's deploy settings. The repo-URL allowlist used a `Zend_Validate_Callback` whose array-options form mis-binds the callback on Plesk's Zend build; the check now runs in the controller instead. Allowlist behaviour is unchanged (SSH + admin-configured GitHub org, enforced again at deploy time)
+
 ## v2.2.0
 
 - Teams deploy notifications are now **Adaptive Cards** (icon + title, fact set, and Open site / View commit actions) sent as the Power Automate Workflows envelope, matching the nassau deployer. **Action required:** the Teams webhook must be a Teams *Workflow* URL ("Post to a channel when a webhook request is received") — legacy Office 365 connector URLs no longer render these cards. Reconfigure the webhook under Extension Settings after upgrading

--- a/xve-laravel-kit/src/meta.xml
+++ b/xve-laravel-kit/src/meta.xml
@@ -4,7 +4,7 @@
     <name>XVE Laravel Kit</name>
     <description>Atomic deployments with rollback, Laravel management tools, .env editor, artisan console, and log viewer. Built for zero-downtime deploys from Git repositories.</description>
     <category>developer</category>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <release>1</release>
     <vendor>XVE BV</vendor>
     <url>https://xve.be</url>

--- a/xve-laravel-kit/src/plib/controllers/DomainController.php
+++ b/xve-laravel-kit/src/plib/controllers/DomainController.php
@@ -191,7 +191,17 @@ class DomainController extends pm_Controller_Action
         $form = new Modules_XveLaravelKit_Form_Settings($this->_domain, $this->_settings);
 
         if ($this->getRequest()->isPost() && $form->isValid($this->getRequest()->getPost())) {
-            $this->_settings->setGitRepo($form->getValue('git_repo'));
+            // Repo URL allowlist (SSH + an admin-configured GitHub org). Enforced
+            // here rather than via a Zend_Validate_Callback, whose array-options
+            // form mis-binds the callback on this Plesk's Zend build. Deploy-time
+            // enforcement in Deployer is the second layer.
+            $gitRepo = trim((string) $form->getValue('git_repo'));
+            if (!Modules_XveLaravelKit_DeploySettings::validateRepoUrl($gitRepo)) {
+                $this->_status->addMessage('error', 'Repository URL must be an SSH URL to an allowed GitHub org, e.g. git@github.com:your-org/your-repo.git. Add the org under Extension Settings \xe2\x86\x92 Allowed Git Repositories.');
+                $this->view->form = $form;
+                return;
+            }
+            $this->_settings->setGitRepo($gitRepo);
             $this->_settings->setBranch($form->getValue('branch'));
             $this->_settings->setSharedDirs($form->getValue('shared_dirs'));
             $this->_settings->setSharedFiles($form->getValue('shared_files'));

--- a/xve-laravel-kit/src/plib/library/Form/Settings.php
+++ b/xve-laravel-kit/src/plib/library/Form/Settings.php
@@ -22,12 +22,6 @@ class Modules_XveLaravelKit_Form_Settings extends pm_Form_Simple
             'required' => true,
             'validators' => [
                 ['NotEmpty', true],
-                ['Callback', false, [
-                    'callback' => ['Modules_XveLaravelKit_DeploySettings', 'validateRepoUrl'],
-                    'messages' => [
-                        Zend_Validate_Callback::INVALID_VALUE => 'Repository URL must be an SSH URL to an allowed GitHub org, e.g. git@github.com:your-org/your-repo.git',
-                    ],
-                ]],
             ],
             'description' => 'SSH URL to an allowed GitHub repo only, e.g. git@github.com:your-org/your-repo.git',
         ]);


### PR DESCRIPTION
## Bug (live)

Opening/saving a domain's deploy settings throws:

```
TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, array callback must have exactly two members (Callback.php:37)
```

## Cause

The `git_repo` field validated the repo-URL allowlist with a `Zend_Validate_Callback` in array-options form:

```php
['Callback', false, ['callback' => ['Modules_XveLaravelKit_DeploySettings', 'validateRepoUrl'], 'messages' => [...]]]
```

On Plesk's Zend build, that options form mis-binds the callback — at `isValid()` time `_callback` is a 1-element array, so `call_user_func` fails. (Bram's #21/#22 `Int` validator fixes were a different validator class, `Zend_Validate_Int`, and didn't touch this path.)

## Fix

Drop the form-level `Callback` validator and enforce the allowlist in `DomainController::settingsAction()` — reject with a clear message before saving if `validateRepoUrl()` fails. No dependency on Zend's callback option-parsing.

**Security unchanged:** the allowlist (SSH + admin-configured GitHub org, fails closed) is still enforced, and `Deployer` still re-checks at deploy time as the second layer.

## Verification

- `php -l` clean on both changed files.
- 61 PHPUnit tests pass (`validateRepoUrl` unit tests unchanged).
- Grep confirms no `Zend_Validate_Callback` / `'Callback'` validator remains in src.