### PR TITLE
fix(dev): install shipped sbin dispatcher in dev container, not hand-written eval

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
       # Live-mount extension source for development
       - ./xve-laravel-kit/src/plib:/usr/local/psa/admin/plib/modules/xve-laravel-kit
       - ./xve-laravel-kit/src/htdocs:/usr/local/psa/admin/htdocs/modules/xve-laravel-kit
-      # Sbin init script — auto-runs on container start via systemd
+      # Sbin dispatcher source — installed (not hand-written) by init-sbin.sh
+      - ./xve-laravel-kit/src/sbin:/opt/xve-sbin:ro
+      # init-sbin script — auto-runs on container start via systemd
       - ./init-sbin.sh:/opt/init-sbin.sh:ro
       - ./init-sbin.service:/etc/systemd/system/init-sbin.service:ro
     cap_add:

--- a/init-sbin.sh
+++ b/init-sbin.sh
@@ -26,15 +26,16 @@ fi
 EXT="xve-laravel-kit"
 SCRIPT_NAME="xve-exec.sh"
 
-# Create sbin script (the actual script that runs as root)
+# Install the real sbin dispatcher from the mounted source (NOT a hand-written
+# copy) so the dev container runs the exact allowlisted script that ships.
 SBIN_DIR="/usr/local/psa/admin/sbin/modules/$EXT"
+SBIN_SRC="/opt/xve-sbin/$SCRIPT_NAME"
 mkdir -p "$SBIN_DIR"
-cat > "$SBIN_DIR/$SCRIPT_NAME" << 'SCRIPT'
-#!/bin/bash
-eval "$1"
-SCRIPT
-chmod 0700 "$SBIN_DIR/$SCRIPT_NAME"
-chown root:root "$SBIN_DIR/$SCRIPT_NAME"
+if [ ! -f "$SBIN_SRC" ]; then
+    echo "ERROR: $SBIN_SRC not found. Mount ./xve-laravel-kit/src/sbin to /opt/xve-sbin (see docker-compose.yml)." >&2
+    exit 1
+fi
+install -m 0700 -o root -g root "$SBIN_SRC" "$SBIN_DIR/$SCRIPT_NAME"
 
 # Create bin wrapper (setuid symlink to mod_wrapper, which calls sbin)
 BIN_DIR="/usr/local/psa/admin/bin/modules/$EXT"


### PR DESCRIPTION
Closes #17.

## Problem

`init-sbin.sh` recreated the privileged Plesk sbin script with an inline heredoc:

```bash
cat > "$SBIN_DIR/$SCRIPT_NAME" << 'SCRIPT'
#!/bin/bash
eval "$1"
SCRIPT
```

So the dev container ran the **pre-hardening `eval` wrapper** while the shipped extension zip ships the allowlisted argv dispatcher (`src/sbin/xve-exec.sh`). Local testing exercised code that no longer matches production.

## Fix

- `docker-compose.yml`: mount the sbin source read-only — `./xve-laravel-kit/src/sbin:/opt/xve-sbin:ro`.
- `init-sbin.sh`: `install -m 0700 -o root -g root` the real dispatcher from that mount instead of hand-writing `eval`. If the mount is missing it errors out (exit 1) rather than silently falling back to `eval`.

The dev container now runs the exact script that ships, and future dispatcher changes need no edit to `init-sbin.sh`.

## Scope / verification

- Dev tooling only — `init-sbin.sh` / `docker-compose.yml` are **not** part of `build.sh` output, so no extension version bump.
- `bash -n init-sbin.sh` clean; `docker compose config -q` validates; no `eval` remains in `init-sbin.sh`.