### PR TITLE
fix(log): read the daily-channel log instead of only laravel.log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.2
+
+- Fix the Log tab showing "Log file is empty or does not exist yet" for every app on Monolog's `daily` channel. It read `shared/storage/logs/laravel.log` unconditionally, but the daily channel writes `laravel-Y-m-d.log` and never creates that file — so the tab stayed blank no matter how much the app logged (found on an app writing 3.2 MB/day). The active log is now resolved by picking `laravel.log` when present, otherwise the newest `laravel-Y-m-d.log`, and the tab shows which file it is reading. `Clear Log` truncates that same file, leaving older dated logs intact
+
 ## v2.2.1
 
 - Fix `TypeError: array callback must have exactly two members` (Zend Callback.php) when opening/saving a domain's deploy settings. The repo-URL allowlist used a `Zend_Validate_Callback` whose array-options form mis-binds the callback on Plesk's Zend build; the check now runs in the controller instead. Allowlist behaviour is unchanged (SSH + admin-configured GitHub org, enforced again at deploy time)

--- a/xve-laravel-kit/src/meta.xml
+++ b/xve-laravel-kit/src/meta.xml
@@ -4,7 +4,7 @@
     <name>XVE Laravel Kit</name>
     <description>Atomic deployments with rollback, Laravel management tools, .env editor, artisan console, and log viewer. Built for zero-downtime deploys from Git repositories.</description>
     <category>developer</category>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
     <release>1</release>
     <vendor>XVE BV</vendor>
     <url>https://xve.be</url>

--- a/xve-laravel-kit/src/plib/controllers/DomainController.php
+++ b/xve-laravel-kit/src/plib/controllers/DomainController.php
@@ -151,6 +151,7 @@ class DomainController extends pm_Controller_Action
 
         $lines = (int) $this->getRequest()->getParam('lines', 200);
         $this->view->logContents = $this->_deployer->getLogContents($lines);
+        $this->view->logPath = $this->_deployer->getLogRelativePath();
         $this->view->lines = $lines;
     }
 

--- a/xve-laravel-kit/src/plib/library/Deployer.php
+++ b/xve-laravel-kit/src/plib/library/Deployer.php
@@ -714,15 +714,96 @@ class Modules_XveLaravelKit_Deployer
     }
 
     /**
-     * Read the Laravel log file (from shared/storage/logs/).
+     * Pick the active Laravel log file out of a logs-directory listing.
+     *
+     * Static and side-effect free so the selection rules stay unit-testable
+     * without Plesk's filesystem layer.
+     *
+     * @param  string $listing Output of `ls -1r` on the logs directory.
+     * @return string|null Chosen filename, or null when nothing matches.
+     */
+    public static function selectActiveLogFile($listing)
+    {
+        $names = array_filter(array_map('trim', explode("\n", trim((string) $listing))));
+
+        // The `single` channel's file wins when present, regardless of where
+        // the listing happens to place it.
+        if (in_array('laravel.log', $names, true)) {
+            return 'laravel.log';
+        }
+
+        // The pattern keeps unrelated files in this directory
+        // (exchange-rate.log, stock-load.log, ...) out of the picture.
+        $newest = null;
+        foreach ($names as $name) {
+            if (!preg_match('/^laravel-\d{4}-\d{2}-\d{2}\.log$/', $name)) {
+                continue;
+            }
+
+            // The dated names are zero-padded ISO, so a plain string
+            // comparison finds the newest day. Compared explicitly rather
+            // than taking the listing's first match, so the result cannot
+            // depend on how `ls` happened to sort.
+            if ($newest === null || strcmp($name, $newest) > 0) {
+                $newest = $name;
+            }
+        }
+
+        return $newest;
+    }
+
+    /**
+     * Resolve the Laravel log file currently being written.
+     *
+     * The `single` channel writes shared/storage/logs/laravel.log, but the
+     * `daily` channel writes laravel-Y-m-d.log and never creates laravel.log
+     * at all — so hardcoding the single-file name made this tab report
+     * "Log file is empty or does not exist yet" permanently for every app on
+     * the daily channel, no matter how much it was logging.
+     *
+     * @return string|null Absolute path, or null when no Laravel log exists.
+     */
+    private function _resolveLogPath()
+    {
+        $logsDir = $this->_basePath . '/shared/storage/logs';
+
+        try {
+            // `ls` is silenced on a missing directory, so this doubles as the
+            // existence check.
+            $listing = $this->_sbin('ls-1r', [$logsDir]);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        $name = self::selectActiveLogFile($listing);
+
+        return $name === null ? null : $logsDir . '/' . $name;
+    }
+
+    /**
+     * Path of the active Laravel log relative to the vhost root, for display.
+     */
+    public function getLogRelativePath()
+    {
+        $logPath = $this->_resolveLogPath();
+        if ($logPath === null) {
+            return 'shared/storage/logs/laravel.log';
+        }
+
+        return ltrim(substr($logPath, strlen($this->_basePath)), '/');
+    }
+
+    /**
+     * Read the active Laravel log file (from shared/storage/logs/).
      */
     public function getLogContents($lines = 200)
     {
-        $logPath = $this->_basePath . '/shared/storage/logs/laravel.log';
+        $logPath = $this->_resolveLogPath();
+        if ($logPath === null) {
+            return '';
+        }
+
         try {
-            if (!$this->_fileManager->fileExists($logPath)) {
-                return '';
-            }
             $output = $this->_sbin('tail-n', [(string)(int)$lines, $logPath]);
             return $output;
         } catch (\Throwable $e) {
@@ -731,15 +812,20 @@ class Modules_XveLaravelKit_Deployer
     }
 
     /**
-     * Clear the Laravel log file.
+     * Clear the active Laravel log file.
+     *
+     * On the daily channel this truncates today's file only; older dated
+     * files are left alone so history is not destroyed by a single click.
      */
     public function clearLog()
     {
-        $logPath = $this->_basePath . '/shared/storage/logs/laravel.log';
+        $logPath = $this->_resolveLogPath();
+        if ($logPath === null) {
+            return true;
+        }
+
         try {
-            if ($this->_fileManager->fileExists($logPath)) {
-                $this->_sbin('truncate0', [$logPath]);
-            }
+            $this->_sbin('truncate0', [$logPath]);
             return true;
         } catch (\Throwable $e) {
             return false;

--- a/xve-laravel-kit/src/plib/views/scripts/domain/log.phtml
+++ b/xve-laravel-kit/src/plib/views/scripts/domain/log.phtml
@@ -10,7 +10,7 @@
         </button>
     </form>
     <span style="color: #888;">
-        Last <?php echo $this->escape($this->lines); ?> lines of <code>shared/storage/logs/laravel.log</code>
+        Last <?php echo $this->escape($this->lines); ?> lines of <code><?php echo $this->escape($this->logPath); ?></code>
     </span>
 </div>
 

--- a/xve-laravel-kit/tests/Unit/ActiveLogFileSelectionTest.php
+++ b/xve-laravel-kit/tests/Unit/ActiveLogFileSelectionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Modules_XveLaravelKit_Deployer::selectActiveLogFile().
+ *
+ * The Log tab used to read shared/storage/logs/laravel.log unconditionally.
+ * That file only exists on Monolog's `single` channel; an app on the `daily`
+ * channel writes laravel-Y-m-d.log and never creates laravel.log at all, so
+ * the tab reported "Log file is empty or does not exist yet" permanently no
+ * matter how much the app was logging (observed on btb-app-core, whose log
+ * directory held 3.2 MB per day).
+ *
+ * selectActiveLogFile() is static and pure precisely so these rules can be
+ * exercised without a live Plesk environment, matching how the other
+ * validation logic in this extension is tested.
+ */
+class ActiveLogFileSelectionTest extends TestCase
+{
+    /** `ls -1r` output for a daily-channel app, newest first. */
+    private const DAILY_LISTING = "stock-load.log\nlaravel-2026-08-14.log\nlaravel-2026-08-13.log\nlaravel-2026-08-01.log\nexchange-rate.log";
+
+    private function select(string $listing): ?string
+    {
+        return Modules_XveLaravelKit_Deployer::selectActiveLogFile($listing);
+    }
+
+    // ── Daily channel ────────────────────────────────────────────────────────
+
+    public function testPicksNewestDatedFileOnDailyChannel(): void
+    {
+        $this->assertSame(
+            'laravel-2026-08-14.log',
+            $this->select(self::DAILY_LISTING),
+            'the newest dated log must be chosen on the daily channel'
+        );
+    }
+
+    /**
+     * The production path feeds `ls -1r` output, but the choice must not
+     * silently depend on the shell's sort order.
+     */
+    public function testPicksNewestDatedFileRegardlessOfListingOrder(): void
+    {
+        $ascending = "exchange-rate.log\nlaravel-2026-08-01.log\nlaravel-2026-08-13.log\nlaravel-2026-08-14.log";
+
+        $this->assertSame(
+            'laravel-2026-08-14.log',
+            $this->select($ascending),
+            'ascending input must still yield the newest dated log'
+        );
+    }
+
+    public function testIgnoresUnrelatedLogsInTheSameDirectory(): void
+    {
+        $this->assertNull(
+            $this->select("stock-load.log\nexchange-rate.log\nworker.log"),
+            'non-Laravel logs in the same directory must never be selected'
+        );
+    }
+
+    // ── Single channel ───────────────────────────────────────────────────────
+
+    public function testPrefersSingleChannelFileWhenPresent(): void
+    {
+        $this->assertSame(
+            'laravel.log',
+            $this->select("laravel-2026-08-14.log\nlaravel.log"),
+            'laravel.log must win when both channels have written'
+        );
+    }
+
+    public function testPicksSingleChannelFileWhenItIsTheOnlyOne(): void
+    {
+        $this->assertSame('laravel.log', $this->select('laravel.log'));
+    }
+
+    // ── Empty / malformed input ──────────────────────────────────────────────
+
+    /**
+     * `ls` is silenced on a missing directory, so an empty string is the
+     * normal signal for "no logs directory" as well as "no logs yet".
+     */
+    public function testReturnsNullForEmptyListing(): void
+    {
+        $this->assertNull($this->select(''));
+        $this->assertNull($this->select("\n\n  \n"));
+    }
+
+    public function testIgnoresMalformedDateSuffixes(): void
+    {
+        $this->assertNull(
+            $this->select("laravel-2026-08.log\nlaravel-.log\nlaravel-20260814.log"),
+            'only fully-formed Y-m-d suffixes are Laravel daily logs'
+        );
+    }
+
+    public function testToleratesSurroundingWhitespace(): void
+    {
+        $this->assertSame(
+            'laravel-2026-08-14.log',
+            $this->select("  laravel-2026-08-14.log  \n  laravel-2026-08-13.log  ")
+        );
+    }
+}


### PR DESCRIPTION
## The bug

The Log tab read `shared/storage/logs/laravel.log` unconditionally.

That file only exists on Monolog's `single` channel. An app on the **`daily`** channel writes `laravel-Y-m-d.log` and never creates `laravel.log` at all — so the tab showed:

> Log file is empty or does not exist yet.

...permanently, no matter how much the app was logging.

Found while debugging `btb-app-core.web-dev-xenops.gdwt.be`, whose logs directory looked like this while the tab claimed it was empty:

```
laravel-2026-08-13.log   3.2 MB
laravel-2026-08-14.log   1.9 MB   <- being written right now
exchange-rate.log
stock-load.log
```

The practical cost is worse than a blank tab: it makes the tab actively misleading during an incident, because "no log" reads as "nothing is happening".

## The fix

- Resolve the active file: `laravel.log` when present, otherwise the newest `laravel-Y-m-d.log`.
- The header now shows **which** file is being read instead of a hardcoded path.
- `Clear Log` truncates that same resolved file, so older dated logs survive a click rather than the button silently doing nothing.
- Unrelated files in the same directory (`exchange-rate.log`, `stock-load.log`, ...) are never selected.

Directory listing uses the existing `ls-1r` sbin action — no new privileged operation is introduced.

## Tests

8 cases in `tests/Unit/ActiveLogFileSelectionTest.php`, covering daily selection, single-channel preference, unrelated-file rejection, malformed date suffixes, whitespace and empty input.

Selection is a static, side-effect-free `selectActiveLogFile()` specifically so it is testable without a live Plesk environment — the same approach already used for the artisan / repo-URL / shared-path validators.

Worth noting: **writing those tests caught a real weakness in my first draft.** It returned the listing's first match, which quietly depended on `ls -1r` ordering — feed it an ascending listing and it picks the *oldest* log. It now compares the ISO dates explicitly, so the result cannot be reordered into being wrong. That test failed before the change and passes after.

Full suite: 69 passed (61 pre-existing + 8 new). `php -l` clean on all three touched PHP/phtml files; `meta.xml` validated as XML.

Version bumped to **2.2.2** with a CHANGELOG entry, per repo convention.
